### PR TITLE
Wiremock stubs should have the body defined under bodyPatterns, and not body.

### DIFF
--- a/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
+++ b/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
@@ -84,7 +84,7 @@ class DslToWiremockClientConverterSpec extends Specification {
 				"request":{
 					"method":"PUT",
 					"url":"/api/12",
-					"body": {
+					"bodyPatterns": {
 						"equalTo": "[{\\"created_at\\":\\"Sat Jul 26 09:38:57 +0000 2014\\",\\"id\\":492967299297845248,\\"id_str\\":\\"492967299297845248\\",\\"place\\":{\\"attributes\\":{},\\"bounding_box\\":{\\"coordinates\\":[[[-77.119759,38.791645],[-76.909393,38.791645],[-76.909393,38.995548],[-77.119759,38.995548]]],\\"type\\":\\"Polygon\\"},\\"country\\":\\"United States\\",\\"country_code\\":\\"US\\",\\"full_name\\":\\"Washington, DC\\",\\"id\\":\\"01fbe706f872cb32\\",\\"name\\":\\"Washington\\",\\"place_type\\":\\"city\\",\\"url\\":\\"http://api.twitter.com/1/geo/id/01fbe706f872cb32.json\\"},\\"text\\":\\"Gonna see you at Warsaw\\"}]"
 					},
 					"headers": {

--- a/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockRequestStubStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockRequestStubStrategy.groovy
@@ -39,7 +39,7 @@ class WiremockRequestStubStrategy extends BaseWiremockStubStrategy {
 
 	private Map<String, Object> appendBody(ClientRequest clientRequest) {
 		Object body = clientRequest?.body?.clientValue
-		return body != null ? [body: [equalTo: parseBody(body)]] : [:]
+		return body != null ? [bodyPatterns: [equalTo: parseBody(body)]] : [:]
 	}
 
 	private String parseBody(Object responseBodyObject) {

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
@@ -140,7 +140,7 @@ class WiremockGroovyDslSpec extends Specification {
     "request": {
         "method": "GET",
         "urlPattern": "/[0-9]{2}",
-        "body": {
+        "bodyPatterns": {
 			"equalTo":"{\\"name\\":\\"Jan\\"}"
         }
     },

--- a/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
+++ b/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
@@ -51,7 +51,7 @@ class BasicFunctionalSpec extends IntegrationSpec {
             }
         },
         "url": "/api/12",
-        "body": {
+        "bodyPatterns": {
             "equalTo": "[{\\"text\\":\\"Gonna see you at Warsaw\\"}]"
         }
     },


### PR DESCRIPTION
This should fix https://github.com/Codearte/accurest/issues/40.
