### PR TITLE
Wiremock stubs should be generated with bodyPatterns as array, and response body as String literal

### DIFF
--- a/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
+++ b/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/DslToWiremockClientConverterSpec.groovy
@@ -84,9 +84,9 @@ class DslToWiremockClientConverterSpec extends Specification {
 				"request":{
 					"method":"PUT",
 					"url":"/api/12",
-					"bodyPatterns": {
-						"equalTo": "[{\\"created_at\\":\\"Sat Jul 26 09:38:57 +0000 2014\\",\\"id\\":492967299297845248,\\"id_str\\":\\"492967299297845248\\",\\"place\\":{\\"attributes\\":{},\\"bounding_box\\":{\\"coordinates\\":[[[-77.119759,38.791645],[-76.909393,38.791645],[-76.909393,38.995548],[-77.119759,38.995548]]],\\"type\\":\\"Polygon\\"},\\"country\\":\\"United States\\",\\"country_code\\":\\"US\\",\\"full_name\\":\\"Washington, DC\\",\\"id\\":\\"01fbe706f872cb32\\",\\"name\\":\\"Washington\\",\\"place_type\\":\\"city\\",\\"url\\":\\"http://api.twitter.com/1/geo/id/01fbe706f872cb32.json\\"},\\"text\\":\\"Gonna see you at Warsaw\\"}]"
-					},
+					"bodyPatterns": [
+						{ "equalTo": "[{\\"created_at\\":\\"Sat Jul 26 09:38:57 +0000 2014\\",\\"id\\":492967299297845248,\\"id_str\\":\\"492967299297845248\\",\\"place\\":{\\"attributes\\":{},\\"bounding_box\\":{\\"coordinates\\":[[[-77.119759,38.791645],[-76.909393,38.791645],[-76.909393,38.995548],[-77.119759,38.995548]]],\\"type\\":\\"Polygon\\"},\\"country\\":\\"United States\\",\\"country_code\\":\\"US\\",\\"full_name\\":\\"Washington, DC\\",\\"id\\":\\"01fbe706f872cb32\\",\\"name\\":\\"Washington\\",\\"place_type\\":\\"city\\",\\"url\\":\\"http://api.twitter.com/1/geo/id/01fbe706f872cb32.json\\"},\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
+					],
 					"headers": {
 						"Content-Type": {
 							"equalTo": "application/vnd.com.ofg.twitter-places-analyzer.v1+json"

--- a/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/WiremockToDslConverterSpec.groovy
+++ b/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/WiremockToDslConverterSpec.groovy
@@ -23,14 +23,7 @@ class WiremockToDslConverterSpec extends Specification {
     },
     "response": {
         "status": 200,
-        "body": {
-            "id": {
-                "value": "132"
-            },
-            "surname": "Kowalsky",
-            "name": "Jan",
-            "created" : "2014-02-02 12:23:43"
-        },
+        "body": "{ \\"id\\": { \\"value\\": \\"132\\" }, \\"surname\\": \\"Kowalsky\\", \\"name\\": \\"Jan\\", \\"created\\": \\"2014-02-02 12:23:43\\" }",
         "headers": {
             "Content-Type": "text/plain",
         }
@@ -193,11 +186,7 @@ class WiremockToDslConverterSpec extends Specification {
   },
   "response": {
     "status": 200,
-    "body": [
-        {"a":1, "c":"3"},
-        "b",
-        "a"
-        ],
+    "body": "[ {\\"a\\":1, \\"c\\":\\"3\\"}, \\"b\\", \\"a\\" ]",
     "headers": {
       "Content-Type": "application/json"
     }

--- a/accurest-core/src/main/groovy/io/coderate/accurest/dsl/BaseWiremockStubStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/coderate/accurest/dsl/BaseWiremockStubStrategy.groovy
@@ -1,10 +1,14 @@
 package io.coderate.accurest.dsl
-
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
 import groovy.transform.TypeChecked
+import groovy.xml.XmlUtil
 import io.coderate.accurest.dsl.internal.Header
 import io.coderate.accurest.dsl.internal.Headers
 
 import java.util.regex.Pattern
+
+import static groovy.json.StringEscapeUtils.escapeJava
 
 @TypeChecked
 abstract class BaseWiremockStubStrategy {
@@ -38,4 +42,26 @@ abstract class BaseWiremockStubStrategy {
 		return [(entryKey): [matches : entry.pattern()]]
 	}
 
+    protected String parseBody(Object body) {
+        String bodyAsString = body as String
+        try {
+            def json = new JsonSlurper().parseText(bodyAsString)
+            return escapeJava(JsonOutput.toJson(bodyAsString))
+        } catch (Exception jsonException) {
+            try {
+                def xml = new XmlSlurper().parseText(bodyAsString)
+                return escapeJava(XmlUtil.serialize(bodyAsString))
+            } catch (Exception xmlException) {
+                return escapeJava(bodyAsString)
+            }
+        }
+    }
+
+    protected String parseBody(List body) {
+        return JsonOutput.toJson(body)
+    }
+
+    protected String parseBody(Map body) {
+        return JsonOutput.toJson(body)
+    }
 }

--- a/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockRequestStubStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockRequestStubStrategy.groovy
@@ -1,15 +1,11 @@
 package io.coderate.accurest.dsl
-import groovy.json.JsonOutput
-import groovy.json.JsonSlurper
+
 import groovy.transform.PackageScope
 import groovy.transform.TypeChecked
-import groovy.xml.XmlUtil
 import io.coderate.accurest.dsl.internal.ClientRequest
 import io.coderate.accurest.dsl.internal.Request
 
 import java.util.regex.Pattern
-
-import static groovy.json.StringEscapeUtils.escapeJava
 
 @TypeChecked
 @PackageScope
@@ -39,30 +35,6 @@ class WiremockRequestStubStrategy extends BaseWiremockStubStrategy {
 
 	private Map<String, Object> appendBody(ClientRequest clientRequest) {
 		Object body = clientRequest?.body?.clientValue
-		return body != null ? [bodyPatterns: [equalTo: parseBody(body)]] : [:]
+		return body != null ? [bodyPatterns: [[equalTo: parseBody(body)]]] : [:]
 	}
-
-	private String parseBody(Object responseBodyObject) {
-		String responseBody = responseBodyObject as String
-		try {
-			def json = new JsonSlurper().parseText(responseBody)
-			return escapeJava(JsonOutput.toJson(responseBody))
-		} catch (Exception jsonException) {
-			try {
-				def xml = new XmlSlurper().parseText(responseBody)
-				return escapeJava(XmlUtil.serialize(responseBody))
-			} catch (Exception xmlException) {
-				return escapeJava(responseBody)
-			}
-		}
-	}
-
-	private String parseBody(List responseBody) {
-		return JsonOutput.toJson(responseBody)
-	}
-
-	private String parseBody(Map responseBody) {
-		return JsonOutput.toJson(responseBody)
-	}
-
 }

--- a/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockResponseStubStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/coderate/accurest/dsl/WiremockResponseStubStrategy.groovy
@@ -1,10 +1,10 @@
 package io.coderate.accurest.dsl
-import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
+import groovy.transform.TypeChecked
 import io.coderate.accurest.dsl.internal.ClientResponse
 import io.coderate.accurest.dsl.internal.Response
 
-@CompileStatic
+@TypeChecked
 @PackageScope
 class WiremockResponseStubStrategy extends BaseWiremockStubStrategy {
 
@@ -20,8 +20,13 @@ class WiremockResponseStubStrategy extends BaseWiremockStubStrategy {
 	}
 
 	private Map<String, Object> buildResponseContent(ClientResponse response) {
-		return [status : response?.status?.clientValue,
-		        body   : response?.body?.clientValue,
-		        headers: buildClientResponseHeadersSection(response.headers)].findAll { it.value }
+		return ([status : response?.status?.clientValue,
+		        headers: buildClientResponseHeadersSection(response.headers)
+        ] << appendBody(response)).findAll { it.value }
 	}
+
+    private Map<String, Object> appendBody(ClientResponse response) {
+        Object body = response?.body?.clientValue
+        return body != null ? [body: parseBody(body)] : [:]
+    }
 }

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
@@ -44,12 +44,7 @@ class WiremockGroovyDslSpec extends Specification {
     },
     "response": {
         "status": 200,
-        "body": {
-            "id": "123",
-            "surname": "Kowalsky",
-            "name": "Jan",
-            "created" : "2014-02-02 12:23:43"
-        },
+        "body": "{\\"id\\":\\"123\\",\\"surname\\":\\"Kowalsky\\",\\"name\\":\\"Jan\\",\\"created\\":\\"2014-02-02 12:23:43\\"}",
         "headers": {
             "Content-Type": "text/plain"
         }
@@ -92,12 +87,7 @@ class WiremockGroovyDslSpec extends Specification {
     },
     "response": {
         "status": 200,
-        "body": {
-            "id": "123",
-            "surname": "Kowalsky",
-            "name": "Jan",
-            "created" : "2014-02-02 12:23:43"
-        },
+        "body": "{\\"created\\":\\"2014-02-02 12:23:43\\",\\"id\\":\\"123\\",\\"name\\":\\"Jan\\",\\"surname\\":\\"Kowalsky\\"}",
         "headers": {
             "Content-Type": "text/plain"
         }
@@ -140,15 +130,15 @@ class WiremockGroovyDslSpec extends Specification {
     "request": {
         "method": "GET",
         "urlPattern": "/[0-9]{2}",
-        "bodyPatterns": {
-			"equalTo":"{\\"name\\":\\"Jan\\"}"
-        }
+        "bodyPatterns": [
+            {
+                "equalTo":"{\\"name\\":\\"Jan\\"}"
+            }
+        ]
     },
     "response": {
         "status": 200,
-        "body": {
-            "name": "Jan"
-        },
+        "body": "{\\"name\\":\\"Jan\\"}",
         "headers": {
             "Content-Type": "text/plain"
         }

--- a/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
+++ b/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
@@ -51,9 +51,9 @@ class BasicFunctionalSpec extends IntegrationSpec {
             }
         },
         "url": "/api/12",
-        "bodyPatterns": {
-            "equalTo": "[{\\"text\\":\\"Gonna see you at Warsaw\\"}]"
-        }
+        "bodyPatterns": [
+            { "equalTo": "[{\\"text\\":\\"Gonna see you at Warsaw\\"}]" }
+        ]
     },
     "response": {
         "status": 200


### PR DESCRIPTION
This should fix https://github.com/Codearte/accurest/issues/43.
