### PR TITLE
DSL: Implemented urlPath and queryParameters with matching for urlPattern and urlPath

### DIFF
--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/WiremockRequestStubStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/WiremockRequestStubStrategy.groovy
@@ -34,42 +34,43 @@ class WiremockRequestStubStrategy extends BaseWiremockStubStrategy {
 	}
 
 	private Map<String, Object> appendUrl(ClientRequest clientRequest) {
-		def urlPath = clientRequest?.urlPath?.clientValue
+		Object urlPath = clientRequest?.urlPath?.clientValue
 		if (urlPath) {
 			return [urlPath: urlPath]
 		}
-		def url = clientRequest?.url?.clientValue
+		Object url = clientRequest?.url?.clientValue
 		return url instanceof Pattern ? [urlPattern: url.pattern()] : [url: url]
 	}
 
 	private Map<String, Object> appendQueryParameters(ClientRequest clientRequest) {
-		def queryParameters = clientRequest?.urlPath?.queryParameters ?: clientRequest?.url?.queryParameters
+		QueryParameters queryParameters = clientRequest?.urlPath?.queryParameters ?: clientRequest?.url?.queryParameters
 		return queryParameters && !queryParameters.parameters.isEmpty() ?
 				[queryParameters: buildUrlPathQueryParameters(queryParameters)] : [:]
 	}
 
-	private Map buildUrlPathQueryParameters(QueryParameters queryParameters) {
+	private Map<String, Object> buildUrlPathQueryParameters(QueryParameters queryParameters) {
 		return queryParameters.parameters.collectEntries { QueryParameter param ->
 			parseQueryParameter(param.name, param.clientValue)
 		}
 	}
 
-	protected Map parseQueryParameter(String name, MatchingStrategy matchingStrategy) {
+	protected Map<String, Object> parseQueryParameter(String name, MatchingStrategy matchingStrategy) {
 		return buildQueryParameter(name, matchingStrategy.clientValue, matchingStrategy.type)
 	}
 
-	protected Map parseQueryParameter(String name, Object value) {
+	protected Map<String, Object> parseQueryParameter(String name, Object value) {
 		return buildQueryParameter(name, value, MatchingStrategy.Type.EQUAL_TO)
 	}
 
-	protected Map parseQueryParameter(String name, Pattern pattern) {
+	protected Map<String, Object> parseQueryParameter(String name, Pattern pattern) {
 		return buildQueryParameter(name, pattern.pattern(), MatchingStrategy.Type.MATCHING)
 	}
 
-	private Map buildQueryParameter(String name, Object value, MatchingStrategy.Type type) {
-		if (value instanceof Pattern) {
-			value = value.pattern()
-		}
+	private Map<String, Object> buildQueryParameter(String name, Pattern pattern, MatchingStrategy.Type type) {
+		return buildQueryParameter(name, pattern.pattern(), type)
+	}
+
+	private Map<String, Object> buildQueryParameter(String name, Object value, MatchingStrategy.Type type) {
 		return [(name): [(type.name) : value]]
 	}
 

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/MatchingStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/MatchingStrategy.groovy
@@ -1,0 +1,34 @@
+package io.codearte.accurest.dsl.internal
+
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString;
+
+@EqualsAndHashCode(includeFields = true)
+@ToString(includePackage = false, includeFields = true, ignoreNulls = true, includeNames = true)
+@CompileStatic
+public class MatchingStrategy extends DslProperty {
+
+    Type type
+
+    MatchingStrategy(Object value, Type type) {
+        super(value)
+        this.type = type
+    }
+
+    MatchingStrategy(DslProperty value, Type type) {
+        super(value.clientValue, value.serverValue)
+        this.type = type
+    }
+
+    enum Type {
+        EQUAL_TO("equalTo"), CONTAINS("contains"), MATCHING("matches"), NOT_MATCHING("doesNotMatch")
+
+        final String name
+
+        Type(name) {
+            this.name = name
+        }
+    }
+
+}

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/MatchingStrategy.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/MatchingStrategy.groovy
@@ -7,7 +7,7 @@ import groovy.transform.ToString;
 @EqualsAndHashCode(includeFields = true)
 @ToString(includePackage = false, includeFields = true, ignoreNulls = true, includeNames = true)
 @CompileStatic
-public class MatchingStrategy extends DslProperty {
+class MatchingStrategy extends DslProperty {
 
     Type type
 

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameter.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameter.groovy
@@ -2,7 +2,9 @@ package io.codearte.accurest.dsl.internal;
 
 import groovy.transform.CompileStatic;
 import groovy.transform.EqualsAndHashCode;
-import groovy.transform.ToString;
+import groovy.transform.ToString
+
+import static io.codearte.accurest.util.ValidateUtils.validateServerValueIsAvailable;
 
 @EqualsAndHashCode(includeFields = true)
 @ToString(includePackage = false, includeFields = true, ignoreNulls = true, includeNames = true)
@@ -13,16 +15,19 @@ class QueryParameter extends DslProperty {
 
     QueryParameter(String name, DslProperty dslProperty) {
         super(dslProperty.clientValue, dslProperty.serverValue)
+        validateServerValueIsAvailable(dslProperty.serverValue, "Query parameter '$name'")
         this.name = name
     }
 
     QueryParameter(String name, MatchingStrategy matchingStrategy) {
         super(matchingStrategy)
+        validateServerValueIsAvailable(matchingStrategy, "Query parameter '$name'")
         this.name = name
     }
 
     QueryParameter(String name, Object value) {
         super(value)
+        validateServerValueIsAvailable(value, "Query parameter '$name'")
         this.name = name
     }
 

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameter.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameter.groovy
@@ -1,0 +1,29 @@
+package io.codearte.accurest.dsl.internal;
+
+import groovy.transform.CompileStatic;
+import groovy.transform.EqualsAndHashCode;
+import groovy.transform.ToString;
+
+@EqualsAndHashCode(includeFields = true)
+@ToString(includePackage = false, includeFields = true, ignoreNulls = true, includeNames = true)
+@CompileStatic
+public class QueryParameter extends DslProperty {
+
+    String name
+
+    QueryParameter(String name, DslProperty dslProperty) {
+        super(dslProperty.clientValue, dslProperty.serverValue)
+        this.name = name
+    }
+
+    QueryParameter(String name, MatchingStrategy matchingStrategy) {
+        super(matchingStrategy)
+        this.name = name
+    }
+
+    QueryParameter(String name, Object value) {
+        super(value)
+        this.name = name
+    }
+
+}

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameter.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameter.groovy
@@ -7,7 +7,7 @@ import groovy.transform.ToString;
 @EqualsAndHashCode(includeFields = true)
 @ToString(includePackage = false, includeFields = true, ignoreNulls = true, includeNames = true)
 @CompileStatic
-public class QueryParameter extends DslProperty {
+class QueryParameter extends DslProperty {
 
     String name
 

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameters.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameters.groovy
@@ -1,0 +1,45 @@
+package io.codearte.accurest.dsl.internal
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import groovy.transform.TypeChecked
+
+@EqualsAndHashCode(includeFields = true)
+@ToString(includePackage = false, includeFields = true, ignoreNulls = true, includeNames = true)
+@TypeChecked
+public class QueryParameters  {
+
+    List<QueryParameter> parameters = []
+
+    public void parameter(Map<String, Object> singleParameter) {
+        Map.Entry<String, Object> first = singleParameter.entrySet().first()
+        parameters << new QueryParameter(first?.key, first?.value)
+    }
+
+    public void parameter(String parameterName, Object parameterValue) {
+        parameters << new QueryParameter(parameterName, parameterValue)
+    }
+
+    def equalTo(Object value) {
+        return new MatchingStrategy(value, MatchingStrategy.Type.EQUAL_TO)
+    }
+
+    def containing(Object value) {
+        return new MatchingStrategy(value, MatchingStrategy.Type.CONTAINS)
+    }
+
+    def matching(Object value) {
+        return new MatchingStrategy(value, MatchingStrategy.Type.MATCHING)
+    }
+
+    def notMatching(Object value) {
+        return new MatchingStrategy(value, MatchingStrategy.Type.NOT_MATCHING)
+    }
+
+    void collect(Closure closure) {
+        parameters?.each {
+            parameter -> closure(parameter)
+        }
+    }
+
+}

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameters.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/QueryParameters.groovy
@@ -7,39 +7,33 @@ import groovy.transform.TypeChecked
 @EqualsAndHashCode(includeFields = true)
 @ToString(includePackage = false, includeFields = true, ignoreNulls = true, includeNames = true)
 @TypeChecked
-public class QueryParameters  {
+class QueryParameters  {
 
     List<QueryParameter> parameters = []
 
-    public void parameter(Map<String, Object> singleParameter) {
+    void parameter(Map<String, Object> singleParameter) {
         Map.Entry<String, Object> first = singleParameter.entrySet().first()
         parameters << new QueryParameter(first?.key, first?.value)
     }
 
-    public void parameter(String parameterName, Object parameterValue) {
+    void parameter(String parameterName, Object parameterValue) {
         parameters << new QueryParameter(parameterName, parameterValue)
     }
 
-    def equalTo(Object value) {
+    MatchingStrategy equalTo(Object value) {
         return new MatchingStrategy(value, MatchingStrategy.Type.EQUAL_TO)
     }
 
-    def containing(Object value) {
+    MatchingStrategy containing(Object value) {
         return new MatchingStrategy(value, MatchingStrategy.Type.CONTAINS)
     }
 
-    def matching(Object value) {
+    MatchingStrategy matching(Object value) {
         return new MatchingStrategy(value, MatchingStrategy.Type.MATCHING)
     }
 
-    def notMatching(Object value) {
+    MatchingStrategy notMatching(Object value) {
         return new MatchingStrategy(value, MatchingStrategy.Type.NOT_MATCHING)
-    }
-
-    void collect(Closure closure) {
-        parameters?.each {
-            parameter -> closure(parameter)
-        }
     }
 
 }

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Request.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Request.groovy
@@ -11,6 +11,7 @@ class Request extends Common {
 
 	DslProperty method
 	Url url
+	UrlPath urlPath
 	Headers headers
 	Body body
 
@@ -20,6 +21,7 @@ class Request extends Common {
 	Request(Request request) {
 		this.method = request.method
 		this.url = request.url
+		this.urlPath = request.urlPath
 		this.headers = request.headers
 		this.body = request.body
 	}
@@ -32,12 +34,44 @@ class Request extends Common {
 		this.method = toDslProperty(method)
 	}
 
-	void url(String url) {
+	void url(Object url) {
 		this.url = new Url(url)
 	}
 
 	void url(DslProperty url) {
 		this.url = new Url(url)
+	}
+
+	void url(Object url, @DelegatesTo(UrlPath) Closure closure) {
+		this.url = new Url(url)
+		closure.delegate = this.url
+		closure()
+	}
+
+	void url(DslProperty url, @DelegatesTo(UrlPath) Closure closure) {
+		this.url = new Url(url)
+		closure.delegate = this.url
+		closure()
+	}
+
+	void urlPath(String path) {
+		this.urlPath = new UrlPath(path)
+	}
+
+	void urlPath(DslProperty path) {
+		this.urlPath = new UrlPath(path)
+	}
+
+	void urlPath(String path, @DelegatesTo(UrlPath) Closure closure) {
+		this.urlPath = new UrlPath(path)
+		closure.delegate = urlPath
+		closure()
+	}
+
+	void urlPath(DslProperty path, @DelegatesTo(UrlPath) Closure closure) {
+		this.urlPath = new UrlPath(path)
+		closure.delegate = urlPath
+		closure()
 	}
 
 	void headers(@DelegatesTo(Headers) Closure closure) {

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Url.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Url.groovy
@@ -1,18 +1,28 @@
 package io.codearte.accurest.dsl.internal
 
+import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
 @ToString(includePackage = false, includeFields = true, includeNames = true)
 @EqualsAndHashCode(includeFields = true)
+@CompileStatic
 class Url extends DslProperty {
 
-	Url(DslProperty bodyAsValue) {
-		super(bodyAsValue.clientValue, bodyAsValue.serverValue)
+	QueryParameters queryParameters
+
+	Url(DslProperty prop) {
+		super(prop.clientValue, prop.serverValue)
 	}
 
-	Url(String bodyAsValue) {
-		super(bodyAsValue)
+	Url(Object url) {
+		super(url)
 	}
-	
+
+	void queryParameters(@DelegatesTo(QueryParameters) Closure closure) {
+		this.queryParameters = new QueryParameters()
+		closure.delegate = queryParameters
+		closure()
+	}
+
 }

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Url.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/Url.groovy
@@ -4,6 +4,8 @@ import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
+import static io.codearte.accurest.util.ValidateUtils.validateServerValueIsAvailable
+
 @ToString(includePackage = false, includeFields = true, includeNames = true)
 @EqualsAndHashCode(includeFields = true)
 @CompileStatic
@@ -13,10 +15,12 @@ class Url extends DslProperty {
 
 	Url(DslProperty prop) {
 		super(prop.clientValue, prop.serverValue)
+		validateServerValueIsAvailable(prop.serverValue, "Url")
 	}
 
 	Url(Object url) {
 		super(url)
+		validateServerValueIsAvailable(url, "Url")
 	}
 
 	void queryParameters(@DelegatesTo(QueryParameters) Closure closure) {

--- a/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/UrlPath.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/dsl/internal/UrlPath.groovy
@@ -1,0 +1,20 @@
+package io.codearte.accurest.dsl.internal
+
+import groovy.transform.CompileStatic;
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString;
+
+@ToString(includePackage = false, includeFields = true, includeNames = true)
+@EqualsAndHashCode(includeFields = true)
+@CompileStatic
+class UrlPath extends Url {
+
+    UrlPath(String path) {
+        super(path)
+    }
+
+    UrlPath(DslProperty path) {
+        super(path)
+    }
+
+}

--- a/accurest-core/src/main/groovy/io/codearte/accurest/util/ValidateUtils.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/util/ValidateUtils.groovy
@@ -1,10 +1,12 @@
 package io.codearte.accurest.util
 
+import groovy.transform.TypeChecked
 import io.codearte.accurest.dsl.internal.DslProperty
 import io.codearte.accurest.dsl.internal.MatchingStrategy
 
 import java.util.regex.Pattern
 
+@TypeChecked
 class ValidateUtils {
 
     static Object validateServerValueIsAvailable(Object value) {
@@ -18,12 +20,12 @@ class ValidateUtils {
     }
 
     static void validateServerValue(Pattern pattern, String msg) {
-        throw new IllegalStateException("$msg can't be a pattern")
+        throw new IllegalStateException("$msg can't be a pattern for the server side")
     }
 
     static void validateServerValue(MatchingStrategy matchingStrategy, String msg) {
         if (matchingStrategy.type != MatchingStrategy.Type.EQUAL_TO) {
-            throw new IllegalStateException("$msg can't be of matching type: $matchingStrategy.type")
+            throw new IllegalStateException("$msg can't be of a matching type: $matchingStrategy.type for the server side")
         }
         validateServerValue(matchingStrategy.serverValue, msg)
     }

--- a/accurest-core/src/main/groovy/io/codearte/accurest/util/ValidateUtils.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/util/ValidateUtils.groovy
@@ -1,0 +1,39 @@
+package io.codearte.accurest.util
+
+import io.codearte.accurest.dsl.internal.DslProperty
+import io.codearte.accurest.dsl.internal.MatchingStrategy
+
+import java.util.regex.Pattern
+
+class ValidateUtils {
+
+    static Object validateServerValueIsAvailable(Object value) {
+        validateServerValueIsAvailable(value, "Server value")
+        return value
+    }
+
+    static Object validateServerValueIsAvailable(Object value, String msg) {
+        validateServerValue(value, msg)
+        return value
+    }
+
+    static void validateServerValue(Pattern pattern, String msg) {
+        throw new IllegalStateException("$msg can't be a pattern")
+    }
+
+    static void validateServerValue(MatchingStrategy matchingStrategy, String msg) {
+        if (matchingStrategy.type != MatchingStrategy.Type.EQUAL_TO) {
+            throw new IllegalStateException("$msg can't be of matching type: $matchingStrategy.type")
+        }
+        validateServerValue(matchingStrategy.serverValue, msg)
+    }
+
+    static void validateServerValue(DslProperty value, String msg) {
+        validateServerValue(value.serverValue, msg)
+    }
+
+    static void validateServerValue(Object value, String msg) {
+        // OK
+    }
+
+}

--- a/accurest-core/src/test/groovy/io/codearte/accurest/builder/SpockMethodBuilderSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/builder/SpockMethodBuilderSpec.groovy
@@ -171,40 +171,40 @@ class SpockMethodBuilderSpec extends Specification {
 
 	def "should generate a call with an url path and query parameters"() {
 		given:
-		GroovyDsl contractDsl = GroovyDsl.make {
-			request {
-				method 'GET'
-				urlPath('/users') {
-					queryParameters {
-						parameter 'limit': $(client(equalTo("20")), server(equalTo("10")))
-						parameter 'offset': $(client(containing("20")), server(equalTo("20")))
-						parameter 'filter': "email"
-						parameter 'sort': equalTo("name")
-						parameter 'search': $(client(notMatching(~/^\/[0-9]{2}$/)), server("55"))
-						parameter 'age': $(client(notMatching("^\\w*\$")), server("99"))
-						parameter 'name': $(client(matching("Denis.*")), server("Denis.Stepanov"))
+			GroovyDsl contractDsl = GroovyDsl.make {
+				request {
+					method 'GET'
+					urlPath('/users') {
+						queryParameters {
+							parameter 'limit': $(client(equalTo("20")), server(equalTo("10")))
+							parameter 'offset': $(client(containing("20")), server(equalTo("20")))
+							parameter 'filter': "email"
+							parameter 'sort': equalTo("name")
+							parameter 'search': $(client(notMatching(~/^\/[0-9]{2}$/)), server("55"))
+							parameter 'age': $(client(notMatching("^\\w*\$")), server("99"))
+							parameter 'name': $(client(matching("Denis.*")), server("Denis.Stepanov"))
+						}
 					}
 				}
-			}
-			response {
-				status 200
-				body """
-				{
-					"property1": "a",
-					"property2": "b"
+				response {
+					status 200
+					body """
+					{
+						"property1": "a",
+						"property2": "b"
+					}
+					"""
 				}
-				"""
 			}
-		}
-		SpockMethodBodyBuilder builder = new SpockMethodBodyBuilder(contractDsl)
-		BlockBuilder blockBuilder = new BlockBuilder(" ")
+			SpockMethodBodyBuilder builder = new SpockMethodBodyBuilder(contractDsl)
+			BlockBuilder blockBuilder = new BlockBuilder(" ")
 		when:
-		builder.appendTo(blockBuilder)
-		def spockTest = blockBuilder.toString()
+			builder.appendTo(blockBuilder)
+			def spockTest = blockBuilder.toString()
 		then:
-		spockTest.contains('get("/users?limit=10&offset=20&filter=email&sort=name&search=55&age=99&name=Denis.Stepanov")')
-		spockTest.contains('responseBody.property1 == "a"')
-		spockTest.contains('responseBody.property2 == "b"')
+			spockTest.contains('get("/users?limit=10&offset=20&filter=email&sort=name&search=55&age=99&name=Denis.Stepanov")')
+			spockTest.contains('responseBody.property1 == "a"')
+			spockTest.contains('responseBody.property2 == "b"')
 	}
 
 }

--- a/accurest-core/src/test/groovy/io/codearte/accurest/builder/SpockMethodBuilderSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/builder/SpockMethodBuilderSpec.groovy
@@ -169,4 +169,42 @@ class SpockMethodBuilderSpec extends Specification {
 			blockBuilder.toString().contains("responseBody.property2 ==~ java.util.regex.Pattern.compile('[0-9]{3}')")
 	}
 
+	def "should generate a call with an url path and query parameters"() {
+		given:
+		GroovyDsl contractDsl = GroovyDsl.make {
+			request {
+				method 'GET'
+				urlPath('/users') {
+					queryParameters {
+						parameter 'limit': $(client(equalTo("20")), server(equalTo("10")))
+						parameter 'offset': $(client(containing("20")), server(equalTo("20")))
+						parameter 'filter': "email"
+						parameter 'sort': equalTo("name")
+						parameter 'search': $(client(notMatching(~/^\/[0-9]{2}$/)), server("55"))
+						parameter 'age': $(client(notMatching("^\\w*\$")), server("99"))
+						parameter 'name': $(client(matching("Denis.*")), server("Denis.Stepanov"))
+					}
+				}
+			}
+			response {
+				status 200
+				body """
+				{
+					"property1": "a",
+					"property2": "b"
+				}
+				"""
+			}
+		}
+		SpockMethodBodyBuilder builder = new SpockMethodBodyBuilder(contractDsl)
+		BlockBuilder blockBuilder = new BlockBuilder(" ")
+		when:
+		builder.appendTo(blockBuilder)
+		def spockTest = blockBuilder.toString()
+		then:
+		spockTest.contains('get("/users?limit=10&offset=20&filter=email&sort=name&search=55&age=99&name=Denis.Stepanov")')
+		spockTest.contains('responseBody.property1 == "a"')
+		spockTest.contains('responseBody.property2 == "b"')
+	}
+
 }

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
@@ -322,13 +322,13 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 					method 'GET'
 					urlPath($(client("users"), server("items"))) {
 						queryParameters {
-							parameter 'limit': $(client(equalTo("20")), server(containing("10")))
-							parameter 'offset': containing("10")
+							parameter 'limit': $(client(equalTo("20")), server("10"))
+							parameter 'offset': $(client(containing("10")), server("10"))
 							parameter 'filter': "email"
-							parameter 'sort': ~/^[0-9]{10}$/
-							parameter 'search': $(client(notMatching(~/^\/[0-9]{2}$/)), server(containing("10")))
-							parameter 'age': notMatching("^\\w*\$")
-							parameter 'name': matching("Denis.*")
+							parameter 'sort': $(client(~/^[0-9]{10}$/), server("1234567890"))
+							parameter 'search': $(client(notMatching(~/^\/[0-9]{2}$/)), server("10"))
+							parameter 'age': $(client(notMatching("^\\w*\$")), server(10))
+							parameter 'name': $(client(matching("Denis.*")), server("Denis"))
 						}
 					}
 				}
@@ -435,15 +435,77 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 		stubMappingIsValidWiremockStub(json)
 	}
 
-	def "should generate request with url and queryParameters for client side"() {
-		given:
-		GroovyDsl groovyDsl = GroovyDsl.make {
+	def "should not allow regexp in url for server value"() {
+		when:
+		GroovyDsl.make {
 			request {
 				method 'GET'
 				url(regex(/users\/[0-9]*/)) {
 					queryParameters {
 						parameter 'age': notMatching("^\\w*\$")
 						parameter 'name': matching("Denis.*")
+					}
+				}
+			}
+			response {
+				status 200
+			}
+		}
+		then:
+			def e = thrown(IllegalStateException)
+			e.message.contains "Url can't be a pattern"
+	}
+
+	def "should not allow regexp in query parameter for server value"() {
+		when:
+            GroovyDsl.make {
+                request {
+                    method 'GET'
+                    url("abc") {
+                        queryParameters {
+                            parameter 'age': $(client(notMatching("^\\w*\$")), server(regex(".*")))
+                        }
+                    }
+                }
+                response {
+                    status 200
+                }
+            }
+		then:
+            def e = thrown(IllegalStateException)
+            e.message.contains "Query parameter 'age' can't be a pattern"
+	}
+
+	def "should not allow query parameter unresolvable for a server value"() {
+		when:
+            GroovyDsl.make {
+                request {
+                    method 'GET'
+                    urlPath("users") {
+                        queryParameters {
+                            parameter 'age': notMatching("^\\w*\$")
+                            parameter 'name': matching("Denis.*")
+                        }
+                    }
+                }
+                response {
+                    status 200
+                }
+            }
+		then:
+            def e = thrown(IllegalStateException)
+            e.message.contains "Query parameter 'age' can't be of matching type: NOT_MATCHING"
+	}
+
+	def "should generate request with url and queryParameters for client side"() {
+		given:
+		GroovyDsl groovyDsl = GroovyDsl.make {
+			request {
+				method 'GET'
+				url($(client(regex(/users\/[0-9]*/)), server("users/123"))) {
+					queryParameters {
+						parameter 'age': $(client(notMatching("^\\w*\$")), server(10))
+						parameter 'name': $(client(matching("Denis.*")), server("Denis"))
 					}
 				}
 			}

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
@@ -512,15 +512,15 @@ class WiremockGroovyDslSpec extends WiremockSpec {
     ''')
 	}
 
-	def toJsonString(value) {
+	String toJsonString(value) {
 		new JsonBuilder(value).toPrettyString()
 	}
 
-	def parseJson(json) {
+	Object parseJson(json) {
 		new JsonSlurper().parseText(json)
 	}
 
-	def toWiremockClientJsonStub(groovyDsl) {
+	String toWiremockClientJsonStub(groovyDsl) {
 		new WiremockStubStrategy(groovyDsl).toWiremockClientStub()
 	}
 }

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
@@ -343,7 +343,7 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			{
 				"request": {
 					"method": "GET",
-					"urlPath":"users",
+					"urlPath": "users",
 					"queryParameters": {
 					  "offset": {
 						"contains": "10"
@@ -375,6 +375,64 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 			''')
 		and:
 			stubMappingIsValidWiremockStub(json)
+	}
+
+	def "should generate request with urlPath for client side"() {
+		given:
+		GroovyDsl groovyDsl = GroovyDsl.make {
+			request {
+				method 'GET'
+				urlPath $(client("boxes"), server("items"))
+			}
+			response {
+				status 200
+			}
+		}
+		when:
+		def json = toWiremockClientJsonStub(groovyDsl)
+		then:
+		parseJson(json) == parseJson('''
+			{
+				"request": {
+					"method": "GET",
+					"urlPath": "boxes"
+				},
+				"response": {
+					"status": 200,
+				}
+			}
+			''')
+		and:
+		stubMappingIsValidWiremockStub(json)
+	}
+
+	def "should generate simple request with urlPath for client side"() {
+		given:
+		GroovyDsl groovyDsl = GroovyDsl.make {
+			request {
+				method 'GET'
+				urlPath "boxes"
+			}
+			response {
+				status 200
+			}
+		}
+		when:
+		def json = toWiremockClientJsonStub(groovyDsl)
+		then:
+		parseJson(json) == parseJson('''
+			{
+				"request": {
+					"method": "GET",
+					"urlPath": "boxes"
+				},
+				"response": {
+					"status": 200,
+				}
+			}
+			''')
+		and:
+		stubMappingIsValidWiremockStub(json)
 	}
 
 	def "should generate request with url and queryParameters for client side"() {

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WiremockGroovyDslSpec.groovy
@@ -453,7 +453,7 @@ class WiremockGroovyDslSpec extends WiremockSpec {
 		}
 		then:
 			def e = thrown(IllegalStateException)
-			e.message.contains "Url can't be a pattern"
+			e.message.contains "Url can't be a pattern for the server side"
 	}
 
 	def "should not allow regexp in query parameter for server value"() {
@@ -473,7 +473,7 @@ class WiremockGroovyDslSpec extends WiremockSpec {
             }
 		then:
             def e = thrown(IllegalStateException)
-            e.message.contains "Query parameter 'age' can't be a pattern"
+            e.message.contains "Query parameter 'age' can't be a pattern for the server side"
 	}
 
 	def "should not allow query parameter unresolvable for a server value"() {
@@ -494,7 +494,7 @@ class WiremockGroovyDslSpec extends WiremockSpec {
             }
 		then:
             def e = thrown(IllegalStateException)
-            e.message.contains "Query parameter 'age' can't be of matching type: NOT_MATCHING"
+            e.message.contains "Query parameter 'age' can't be of a matching type: NOT_MATCHING for the server side"
 	}
 
 	def "should generate request with url and queryParameters for client side"() {


### PR DESCRIPTION
Only DSL no Spock tests generating

Example with urlPath:

``` groovy
            GroovyDsl groovyDsl = GroovyDsl.make {
                request {
                    method 'GET'
                    urlPath($(client("users"), server("items"))) {
                        queryParameters {
                            parameter 'limit': $(client(equalTo("20")), server(containing("10")))
                            parameter 'offset': containing("10")
                            parameter 'filter': "email"
                            parameter 'sort': ~/^[0-9]{10}$/
                            parameter 'search': $(client(notMatching(~/^\/[0-9]{2}$/)), server(containing("10")))
                            parameter 'age': notMatching("^\\w*\$")
                            parameter 'name': matching("Denis.*")
                        }
                    }
                }
                response {
                    status 200
                }
            }
```
