### PR TITLE
lang3 version fix

### DIFF
--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWiremockClientStubsFromDslTask.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWiremockClientStubsFromDslTask.groovy
@@ -17,8 +17,8 @@ class GenerateWiremockClientStubsFromDslTask extends ConventionTask {
 
 	@TaskAction
 	void generate() {
-		project.logger.info("Accurest Plugin: Invoking GroovyDSL to Wiremock client stubs conversion")
-		project.logger.debug("From '${getContractsDslDir()}' to '${getStubsOutputDir()}'")
+		logger.info("Accurest Plugin: Invoking GroovyDSL to Wiremock client stubs conversion")
+		logger.debug("From '${getContractsDslDir()}' to '${getStubsOutputDir()}'")
 
 		RecursiveFilesConverter converter = new RecursiveFilesConverter(new DslToWiremockClientConverter(), getContractsDslDir(),
 				getStubsOutputDir())

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ project(':accurest-core') {
 		compile 'org.slf4j:slf4j-api:[1.6.0,)'
 		compile 'org.codehaus.plexus:plexus-utils:[3.0.0,)'
 		compile 'commons-io:commons-io:[2.0,)'
-		compile 'org.apache.commons:commons-lang3:[3.0,)'
+		compile 'org.apache.commons:commons-lang3:[3.3,)'
 		testCompile 'cglib:cglib-nodep:2.2'
 		testCompile 'org.objenesis:objenesis:2.1'
 		testCompile 'com.github.tomakehurst:wiremock:1.53'


### PR DESCRIPTION
Removed unnecessary reference call. Changed the required version of apache-commons-lang3 for accurest-core to 3.3 as we use methods that were introduced in 3.3.
