### PR TITLE
Allow using single quotes for quoting in stub definitions

### DIFF
--- a/accurest-converters/src/main/groovy/io/codearte/accurest/wiremock/WireMockToDslConverter.groovy
+++ b/accurest-converters/src/main/groovy/io/codearte/accurest/wiremock/WireMockToDslConverter.groovy
@@ -1,6 +1,8 @@
 package io.codearte.accurest.wiremock
+
 import groovy.io.FileType
 import groovy.json.JsonOutput
+import groovy.json.JsonParserType
 import groovy.json.JsonSlurper
 import groovy.xml.XmlUtil
 import io.codearte.accurest.dsl.GroovyDsl
@@ -14,7 +16,7 @@ class WireMockToDslConverter {
 	}
 
 	private String convertFromWireMockStub(String wireMockStringStub) {
-		Object wireMockStub = new JsonSlurper().parseText(wireMockStringStub)
+		Object wireMockStub = parseStubDefinition(wireMockStringStub)
 		def request = wireMockStub.request
 		def response = wireMockStub.response
 		def bodyPatterns = request.bodyPatterns
@@ -53,6 +55,10 @@ class WireMockToDslConverter {
 		}
 			}
 		"""
+	}
+
+	private Object parseStubDefinition(String wireMockStringStub) {
+		new JsonSlurper().setType(JsonParserType.LAX).parseText(wireMockStringStub)
 	}
 
 	private String buildHeader(String method, Object value) {

--- a/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/WireMockToDslConverterSpec.groovy
+++ b/accurest-converters/src/test/groovy/io/codearte/accurest/wiremock/WireMockToDslConverterSpec.groovy
@@ -24,7 +24,7 @@ class WireMockToDslConverterSpec extends Specification {
 	},
 	"response": {
 		"status": 200,
-		"body": "{ \\"id\\": { \\"value\\": \\"132\\" }, \\"surname\\": \\"Kowalsky\\", \\"name\\": \\"Jan\\", \\"created\\": \\"2014-02-02 12:23:43\\" }",
+		"body": '{"id": { "value": "132" }, "surname": "Kowalsky", "name": "Jan", "created": "2014-02-02 12:23:43" }',
 		"headers": {
 			"Content-Type": "text/plain"
 		}
@@ -74,7 +74,7 @@ class WireMockToDslConverterSpec extends Specification {
 	}
 
 
-	def 'should convert WireMock stub with response body containing simple JSON'() {
+	def 'should convert WireMock stub with response body containing JSON with escaped double quotes'() {
 		given:
 			String wireMockStub = '''\
 {
@@ -193,7 +193,7 @@ class WireMockToDslConverterSpec extends Specification {
   },
   "response": {
 	"status": 200,
-	"body": "[ {\\"a\\":1, \\"c\\":\\"3\\"}, \\"b\\", \\"a\\" ]",
+	"body": '[ {"a":1, "c":"3"}, "b", "a" ]',
 	"headers": {
 	  "Content-Type": "application/json"
 	}
@@ -232,7 +232,6 @@ class WireMockToDslConverterSpec extends Specification {
 			}""") == expectedGroovyDsl
 	}
 
-
 	def 'should convert WireMock stub with response body containing a nested list'() {
 		given:
 			String wireMockStub = '''\
@@ -248,7 +247,7 @@ class WireMockToDslConverterSpec extends Specification {
   },
   "response": {
 	"status": 200,
-	"body":"[{\\"amount\\":1.01,\\"name\\":\\"Name\\",\\"info\\":{\\"title\\":\\"title1\\",\\"payload\\":null},\\"booleanvalue\\":true,\\"user\\":null},{\\"amount\\":2.01,\\"name\\":\\"Name2\\",\\"info\\":{\\"title\\":\\"title2\\",\\"payload\\":null},\\"booleanvalue\\":true,\\"user\\":null}]"
+	"body": '[{"amount":1.01, "name":"Name", "info":{"title":"title1", "payload":null}, "booleanvalue":true, "user":null}, {"amount":2.01, "name":"Name2", "info":{"title":"title2", "payload":null}, "booleanvalue":true, "user":null}]'
 	}
 }
 '''
@@ -306,7 +305,7 @@ class WireMockToDslConverterSpec extends Specification {
 	"method": "POST",
 	"url": "/test",
 	"bodyPatterns": [{
-		"equalTo": "{\\"property1\\":\\"abc\\",\\"property2\\":\\"2017-01\\",\\"property3\\":\\"666\\",\\"property4\\":1428566412}"
+		"equalTo": '{"property1":"abc", "property2":"2017-01", "property3":"666", "property4":1428566412}'
 	}]
   },
   "response": {
@@ -386,7 +385,7 @@ class WireMockToDslConverterSpec extends Specification {
 	"url" : "/test",
 	"method" : "POST",
 	"bodyPatterns" : [ {
-	  "equalToJson" : "{\\"pan\\":\\"4855141150107894\\",\\"expirationDate\\":\\"2017-01\\",\\"dcvx\\":\\"178\\"}",
+	  "equalToJson" : '{"pan":"4855141150107894", "expirationDate":"2017-01", "dcvx":"178"}',
 	  "jsonCompareMode" : "LENIENT"
 	} ]
   },
@@ -427,7 +426,7 @@ class WireMockToDslConverterSpec extends Specification {
 				"url" : "/test",
 				"method" : "POST",
 				"bodyPatterns" : [ {
-				  "equalTo" : "{\\"pan\\":\\"4855141150107894\\",\\"expirationDate\\":\\"2017-01\\",\\"dcvx\\":\\"178\\"}"
+				  "equalTo" : '{"pan":"4855141150107894", "expirationDate":"2017-01", "dcvx":"178"}'
 				} ]
 			  },
 			  "response" : {
@@ -502,5 +501,4 @@ class WireMockToDslConverterSpec extends Specification {
 	void stubMappingIsValidWireMockStub(String mappingDefinition) {
 		StubMapping.buildFrom(mappingDefinition)
 	}
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ project(':accurest-core') {
 		compile 'org.apache.commons:commons-lang3:[3.3,)'
 		testCompile 'cglib:cglib-nodep:2.2'
 		testCompile 'org.objenesis:objenesis:2.1'
-		testCompile 'com.github.tomakehurst:wiremock:1.53'
+		testCompile 'com.github.tomakehurst:wiremock:1.57'
 	}
 }
 
@@ -101,7 +101,7 @@ project(':accurest-converters') {
 		compile 'org.apache.commons:commons-lang3:[3.0,)'
 		compile 'commons-io:commons-io:[2.0,)'
 		compile 'dk.brics.automaton:automaton:1.11-8' // needed for Xeger
-		testCompile 'com.github.tomakehurst:wiremock:1.53'
+		testCompile 'com.github.tomakehurst:wiremock:1.57'
 		testCompile 'org.hamcrest:hamcrest-all:1.3'
 	}
 }


### PR DESCRIPTION
After tomakehurst/wiremock#280 single quotes can be used for quoting in stub definitions.

To push thing further we could generate stubs without escaping double quotes (e.g. in response body) and have more readable stub definitions.
