### PR TITLE
fix/#108-single-value-validation-fix-after-#106-merge

### DIFF
--- a/accurest-core/src/main/groovy/io/codearte/accurest/builder/SpockMethodBodyBuilder.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/builder/SpockMethodBodyBuilder.groovy
@@ -98,6 +98,9 @@ abstract class SpockMethodBodyBuilder {
 		} else if (contentType == ContentType.XML) {
 			bb.addLine("def responseBody = new XmlSlurper().parseText($responseAsString)")
 			// TODO xml validation
+		}   else {
+			bb.addLine("def responseBody = ($responseAsString)")
+			processBodyElement(bb, "", responseBody)
 		}
 	}
 

--- a/accurest-core/src/test/groovy/io/codearte/accurest/builder/JaxRsClientSpockMethodBuilderSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/builder/JaxRsClientSpockMethodBuilderSpec.groovy
@@ -359,4 +359,26 @@ class JaxRsClientSpockMethodBuilderSpec extends Specification {
 		then:
 			spockTest.contains("entity('', 'application/octet-stream')")
 	}
+
+	def "should generate test for String in response body"() {
+		given:
+			GroovyDsl contractDsl = GroovyDsl.make {
+				request {
+					method "POST"
+					url "test"
+				}
+				response {
+					status 200
+					body "test"
+				}
+			}
+			MockMvcSpockMethodBodyBuilder builder = new MockMvcSpockMethodBodyBuilder(contractDsl)
+			BlockBuilder blockBuilder = new BlockBuilder(" ")
+		when:
+			builder.appendTo(blockBuilder)
+			def spockTest = blockBuilder.toString()
+		then:
+			spockTest.contains('def responseBody = (response.body.asString())')
+			spockTest.contains('responseBody == "test"')
+	}
 }

--- a/accurest-core/src/test/groovy/io/codearte/accurest/builder/MockMvcSpockMethodBuilderSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/builder/MockMvcSpockMethodBuilderSpec.groovy
@@ -306,4 +306,26 @@ class MockMvcSpockMethodBuilderSpec extends Specification {
 		then:
 			spockTest.contains(".body('')")
 	}
+
+	def "should generate test for String in response body"() {
+		given:
+			GroovyDsl contractDsl = GroovyDsl.make {
+				request {
+					method "POST"
+					url "test"
+				}
+				response {
+					status 200
+					body "test"
+				}
+			}
+			MockMvcSpockMethodBodyBuilder builder = new MockMvcSpockMethodBodyBuilder(contractDsl)
+			BlockBuilder blockBuilder = new BlockBuilder(" ")
+		when:
+			builder.appendTo(blockBuilder)
+			def spockTest = blockBuilder.toString()
+		then:
+			spockTest.contains('def responseBody = (response.body.asString())')
+			spockTest.contains('responseBody == "test"')
+	}
 }


### PR DESCRIPTION
 #106 has changed the logic in test method generation and the fix from  #109 will not work anymore. Modified it to make single value validation possible. Added tests.
