### PR TITLE
Don't generate UTF8 escaping "\u041C\u043E\u0441\u043A\u0432\u0430" in tests 

### DIFF
--- a/accurest-core/src/main/groovy/io/codearte/accurest/builder/SpockMethodBodyBuilder.groovy
+++ b/accurest-core/src/main/groovy/io/codearte/accurest/builder/SpockMethodBodyBuilder.groovy
@@ -1,5 +1,7 @@
 package io.codearte.accurest.builder
+
 import groovy.json.JsonOutput
+import groovy.json.StringEscapeUtils
 import groovy.transform.PackageScope
 import groovy.transform.TypeChecked
 import io.codearte.accurest.dsl.GroovyDsl
@@ -117,7 +119,13 @@ abstract class SpockMethodBodyBuilder {
 
 	protected String getBodyAsString() {
 		Object bodyValue = extractServerValueFromBody(request.body.serverValue)
-		return trimRepeatedQuotes(new JsonOutput().toJson(bodyValue))
+		String json = new JsonOutput().toJson(bodyValue)
+		json = convertUnicodeEscapes(json)
+		return trimRepeatedQuotes(json)
+	}
+
+	protected String convertUnicodeEscapes(String json) {
+		return StringEscapeUtils.unescapeJavaScript(json)
 	}
 
 	protected String trimRepeatedQuotes(String toTrim) {


### PR DESCRIPTION
_More Unicode fixes..._

Solution looks weird but it's the best I have found. 
http://stackoverflow.com/questions/9806246/switch-off-utf-escaping-in-jsonbuilder
