### PR TITLE
Automatic snapshots upload to Nexus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,15 @@ before_install:
  - "cp -r stub-runner/stub-runner-spring/src/test/resources/m2repo/repository/io/codearte/accurest/stubs $HOME/.m2/repository/io/codearte/accurest/"
 
 jdk:
- - oraclejdk7
  - oraclejdk8
 
 install: ./gradlew assemble -s
-script: ./gradlew check funcTest install -s --continue && jdk_switcher use oraclejdk8 && ./scripts/runTests.sh
+script: ./gradlew check funcTest install -s --continue && jdk_switcher use oraclejdk8 && ./scripts/runTests.sh && jdk_switcher use $TRAVIS_JDK_VERSION && ./gradlew uploadSnapshotArchives -s
+
+matrix:
+  include:
+    # Automatic snapshot release only in Java 7 build
+    - jdk: oraclejdk7
+      env:
+       - DO_RELEASE=true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,8 @@ matrix:
       env:
        - DO_RELEASE=true
 
+env:
+  global:
+    - secure: NbEQ9t5nGKW0LKmOSV4rTiEbYJARM2rynQBdSXkoILbp+nNaCD6uN41tUu8HrjgbjUDMepFUU+hmGQ47Q2vz5L3NzvW+oHBLgrIu6uAimpdR8qyBE899MBKPE19LsvUOeE9B9TydJgYlY+UEYgxwssUwxsN0RqyY4EErQWMNC8k=
+    - secure: zCjkMhjF5TbZehNmOK7EV68J35tuc0etWG/ia0eVTjgIv2kp9islJZ3+Jm/gDgkcv2Ydq3oAU2jFbVkUPSSstV3L5KANsighm2qn9tVzRrbTCfM55zcBhnoE0oZHTPNrLoScz0X5sM8Xuvi6ChjGf+lqAxnFW6tFMjx+1uhUIXU=
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ jdk:
  - oraclejdk7
  - oraclejdk8
 
-install: ./gradlew assemble
-script: ./gradlew clean check funcTest install --stacktrace --continue && jdk_switcher use oraclejdk8 && ./scripts/runTests.sh
+install: ./gradlew assemble -s
+script: ./gradlew check funcTest install -s --continue && jdk_switcher use oraclejdk8 && ./scripts/runTests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jdk:
  - oraclejdk8
 
 install: ./gradlew assemble -s
-script: ./gradlew check funcTest install -s --continue && jdk_switcher use oraclejdk8 && ./scripts/runTests.sh && jdk_switcher use $TRAVIS_JDK_VERSION && ./gradlew uploadSnapshotArchives -s
+script: ./gradlew check funcTest install -s --continue && jdk_switcher use oraclejdk8 && ./scripts/runTests.sh && jdk_switcher use $TRAVIS_JDK_VERSION && ./gradlew uploadSnapshotArchives -x check -s
 
 matrix:
   include:

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 		if (project.hasProperty('fatJar')) jcenter()
 	}
 	dependencies {
-		classpath "pl.allegro.tech.build:axion-release-plugin:1.3.4"
+		classpath "pl.allegro.tech.build:axion-release-plugin:1.3.2"
 		classpath "com.bmuschko:gradle-nexus-plugin:2.3"
 		classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
 		if (project.hasProperty('fatJar')) classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ nexusStaging {
 	stagingProfileId = '93c08fdebde1ff'
 }
 
+apply from: "$rootDir/gradle/releaseRoot.gradle"
+
 subprojects {
 	apply plugin: 'groovy'
 	apply from: "$rootDir/gradle/release.gradle"
@@ -212,3 +214,4 @@ buildscript {
 }
 
 apply plugin: "com.palantir.idea-test-fix"
+

--- a/docs/src/docs/asciidoc/rest.adoc
+++ b/docs/src/docs/asciidoc/rest.adoc
@@ -29,6 +29,19 @@ dependencies {
 }
 ----
 
+====== Snapshot versions
+
+Add the additional snapshot repository to your build.gradle to use snapshot versions which are automatically uploaded after every successful build:
+
+[source,groovy,indent=0]
+----
+repositories {
+    (...)
+    //Required only for SNAPSHOT versions
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+}
+----
+
 ===== Add maven plugin
 
 [source,xml,indent=0]

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -38,3 +38,22 @@ modifyPom {
 
 uploadArchives.dependsOn { check }
 
+
+task uploadSnapshotArchives {
+	if (shouldUploadSnapshotArchives) {
+		dependsOn { uploadArchives }
+	}
+        onlyIf { shouldUploadSnapshotArchives }
+}
+
+//for Travis to leverage secure variables
+project.ext {
+	if (!hasProperty('nexusUsername') && System.env.NEXUS_USERNAME) {
+		nexusUsername = System.env.NEXUS_USERNAME
+	}
+	if (!hasProperty('nexusPassword') && System.env.NEXUS_PASSWORD) {
+		nexusPassword = System.env.NEXUS_PASSWORD
+	}
+}
+
+

--- a/gradle/releaseRoot.gradle
+++ b/gradle/releaseRoot.gradle
@@ -1,0 +1,16 @@
+assert project == rootProject
+
+project.ext {
+        isSnapshot = project.version.endsWith("-SNAPSHOT")
+        currentBranch = System.env.TRAVIS_BRANCH
+        isPr = !isNullOrFalse(System.env.TRAVIS_PULL_REQUEST)
+        doRelease = !isNullOrFalse(System.env.DO_RELEASE)
+        shouldUploadSnapshotArchives = isSnapshot && currentBranch == 'master' && !isPr && doRelease
+}
+
+logger.lifecycle("Automatic snapshot release: {} (isSnapshot: {}, currentBranch: {}, isPr: {}, doRelease: {})", shouldUploadSnapshotArchives, isSnapshot, currentBranch, isPr, doRelease)
+
+private boolean isNullOrFalse(def env) {
+        env == null || env == "false" || (env instanceof Boolean && !env)
+}
+


### PR DESCRIPTION
This PR provides automatic upload do Sonatype Nexus repository after every successful build from master. Thanks to that people will be able to verify fix/modification prior to the next version release.

I'm not very satisfies with the implementation (that's Gradle, what could I expect ;) ). Suggestions are welcome.

Test snapshot versions uploaded from Travis:
https://oss.sonatype.org/content/repositories/snapshots/io/codearte/accurest/accurest-core/1.1.1-SNAPSHOT/

Btw, the Gradle execution with `uploadSnapshotArchives` should treat `check` as up-to-date, but it doesn't (maybe those "strange" acceptance tests scripts modify something). Temporarily, as a workaround tests are disabled in the second run.

Btw2, I'm not sure in what place it would be best to put documentation for that.
