### PR TITLE
extension which allows to take values from request body, path or query param

### DIFF
--- a/stub-runner/stub-runner/build.gradle
+++ b/stub-runner/stub-runner/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	testCompile 'cglib:cglib-nodep:2.2'
 	testCompile 'org.objenesis:objenesis:2.1'
 	testCompile 'ch.qos.logback:logback-classic:1.1.3'
+	testCompile 'com.jayway.restassured:rest-assured:2.9.0'
+	testCompile project(':accurest-testing-utils')
 }
 
 ext {

--- a/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/extension/EchoRequestTransformer.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/extension/EchoRequestTransformer.groovy
@@ -1,0 +1,100 @@
+package io.codearte.accurest.stubrunner.extension
+
+import com.github.tomakehurst.wiremock.common.FileSource
+import com.github.tomakehurst.wiremock.extension.Parameters
+import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.http.ResponseDefinition
+import com.jayway.jsonpath.JsonPath
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.like
+import static org.apache.commons.lang3.StringUtils.isBlank
+import static org.apache.commons.lang3.StringUtils.isNotBlank
+
+/**
+ * @author Norbert Krzysztofik
+ */
+class EchoRequestTransformer extends ResponseDefinitionTransformer {
+
+    private final Pattern echoBodyElementTagPattern =  ~/echoBodyElement\((.+?)\)/
+    private final Pattern echoPathVariableTagPattern =  ~/echoPathVariable\((.+?)\)/
+    private final Pattern echoQueryParamTagPattern =  ~/echoQueryParam\((.+?)\)/
+
+    @Override
+    ResponseDefinition transform(Request request, ResponseDefinition responseDefinition,
+                                 FileSource files, Parameters parameters) {
+        String responseBody = responseDefinition.getBody()
+
+        if (isBlank(responseBody)) {
+            return responseDefinition;
+        }
+
+        return like(responseDefinition)
+                .but()
+                .withBody(transformResponse(request, responseBody))
+                .build()
+    }
+
+    @Override
+    String name() {
+        'echo-request-property'
+    }
+
+    private String transformResponse(Request request, String responseBody) {
+        String modifiedResponseBody = responseBody
+        String jsonRequestBody = request.getBodyAsString()
+        if (isNotBlank(jsonRequestBody)) {
+            modifiedResponseBody = echoFromRequestBody(modifiedResponseBody, jsonRequestBody)
+        }
+        modifiedResponseBody = echoFromRequestUrl(modifiedResponseBody, request)
+        return modifiedResponseBody
+    }
+
+    private String echoFromRequestUrl(String responseBody, Request request) {
+        String modifiedResponseBody = responseBody
+        modifiedResponseBody = echoPathVariable(modifiedResponseBody, request.getUrl())
+        modifiedResponseBody = echoQueryParam(modifiedResponseBody, request)
+        return modifiedResponseBody
+    }
+
+    private String echoFromRequestBody(String responseBody, String jsonRequestBody) {
+        String modifiedResponseBody = responseBody
+        Matcher echoBodyElementTagFinder = (modifiedResponseBody =~ echoBodyElementTagPattern)
+        echoBodyElementTagFinder.findAll() { String echoBodyElementTag, String pathToElement ->
+            modifiedResponseBody = modifiedResponseBody.replace(echoBodyElementTag,
+                                                                getBodyElementValueFromRequestBody(pathToElement, jsonRequestBody))
+        }
+        return modifiedResponseBody
+    }
+
+    private String echoQueryParam(String responseBody, Request request) {
+        String modifiedResponseBody = responseBody
+        Matcher echoQueryParamTagFinder = (modifiedResponseBody =~ echoQueryParamTagPattern)
+        echoQueryParamTagFinder.findAll() { String echoQueryParamTag, String queryParamName ->
+            modifiedResponseBody = modifiedResponseBody.replace(echoQueryParamTag,
+                                                                request.queryParameter(queryParamName).firstValue())
+        }
+        return modifiedResponseBody
+    }
+
+    private String echoPathVariable(String responseBody, String requestUrl) {
+        String modifiedResponseBody = responseBody
+        Matcher echoPathVariableTagFinder = (modifiedResponseBody =~ echoPathVariableTagPattern)
+        echoPathVariableTagFinder.findAll() { String echoPathVariableTag, String pathVariableName ->
+            modifiedResponseBody = modifiedResponseBody.replace(echoPathVariableTag,
+                                                                getPathVariableValueFromRequestUrl(pathVariableName, requestUrl))
+        }
+        return modifiedResponseBody
+    }
+
+    private static String getBodyElementValueFromRequestBody(String pathToElement, String jsonRequestBody) {
+        return JsonPath.read(jsonRequestBody, "\$.${pathToElement}") as String
+    }
+
+    private static String getPathVariableValueFromRequestUrl(String pathVariableName, String requestUrl) {
+        return requestUrl.find(/${pathVariableName}\/([^\/\?]+?)(\/|$|\?)/) { it[1] }
+    }
+}

--- a/stub-runner/stub-runner/src/test/groovy/io/codearte/accurest/stubrunner/extension/EchoRequestTransformerIntegrationSpec.groovy
+++ b/stub-runner/stub-runner/src/test/groovy/io/codearte/accurest/stubrunner/extension/EchoRequestTransformerIntegrationSpec.groovy
@@ -1,0 +1,114 @@
+package io.codearte.accurest.stubrunner.extension
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import com.jayway.restassured.RestAssured
+import org.junit.Rule
+import spock.lang.Specification
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import static com.github.tomakehurst.wiremock.client.WireMock.matching
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import static com.jayway.restassured.RestAssured.given
+import static org.hamcrest.core.IsEqual.equalTo
+
+/**
+ * @author Norbert Krzysztofik
+ */
+
+class EchoRequestTransformerIntegrationSpec extends Specification {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort()
+                                                                        .extensions(EchoRequestTransformer))
+
+    def 'should return response with data from query params and path' () {
+        given:
+            String stubResponseBody = '''{
+                                           "clients":[
+                                              {
+                                                 "id":echoPathVariable(user),
+                                                 "surname":"Kowalsky",
+                                                 "name":"Jan",
+                                                 "created":"2014-02-02 12:23:43"
+                                              }
+                                           ],
+                                           "pageMetadata":{
+                                              "size":echoQueryParam(size),
+                                              "totalElements":6,
+                                              "totalPages":6,
+                                              "number":echoQueryParam(page)
+                                           }
+                                        }
+                                    '''
+            RestAssured.port = wireMockRule.port()
+            wireMockRule.stubFor(WireMock.get(urlPathMatching("/user/[0-9]+/details"))
+                                .withQueryParam('page', matching('[0-9]+'))
+                                .withQueryParam('size', matching('[0-9]+'))
+                                .willReturn(aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(stubResponseBody)))
+        expect:
+            given().queryParameters(['page':'6', 'size':'1'])
+                   .get('/user/12345/details')
+                   .then()
+                       .statusCode(200)
+                       .contentType('application/json')
+                       .body('clients[0].id', equalTo(12345))
+                       .body('pageMetadata.size', equalTo(1))
+                       .body('pageMetadata.number', equalTo(6))
+    }
+
+    def 'should return response with data from path and request body' () {
+        given:
+            String stubResponseBody = '''{
+                                       "id":echoPathVariable(user),
+                                       "surname":"Kowalsky",
+                                       "name":"Jan",
+                                       "addresses":[
+                                          {
+                                             "declared":{
+                                                "city":"echoBodyElement(addresses[0].declared.city)",
+                                                "street":"echoBodyElement(addresses[0].declared.street)",
+                                                "number":echoBodyElement(addresses[0].declared.number)
+                                             }
+                                          }
+                                       ],
+                                       "created":"2014-02-02 12:23:43"
+                                    }
+                                    '''
+            String requestBody = '''{
+                                       "addresses":[
+                                          {
+                                             "declared":{
+                                                "city":"Warsaw",
+                                                "street":"Okopowa",
+                                                "number":30
+                                             }
+                                          }
+                                       ]
+                                    }
+                                    '''
+            RestAssured.port = wireMockRule.port()
+            wireMockRule.stubFor(WireMock.patch(urlPathMatching("/user/[0-9]+/address"))
+                        .withRequestBody(equalToJson(requestBody))
+                        .willReturn(aResponse()
+                                    .withHeader("Content-Type", "application/json")
+                                    .withStatus(200)
+                                    .withBody(stubResponseBody)))
+        expect:
+            given().body(requestBody)
+                   .patch('/user/666/address')
+                   .then()
+                        .statusCode(200)
+                        .contentType('application/json')
+                        .body('id', equalTo(666))
+                        .body('addresses[0].declared.city', equalTo('Warsaw'))
+                        .body('addresses[0].declared.street', equalTo('Okopowa'))
+                        .body('addresses[0].declared.number', equalTo(30))
+
+    }
+}

--- a/stub-runner/stub-runner/src/test/groovy/io/codearte/accurest/stubrunner/extension/EchoRequestTransformerSpec.groovy
+++ b/stub-runner/stub-runner/src/test/groovy/io/codearte/accurest/stubrunner/extension/EchoRequestTransformerSpec.groovy
@@ -1,0 +1,146 @@
+package io.codearte.accurest.stubrunner.extension
+
+import com.github.tomakehurst.wiremock.http.QueryParameter
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.http.ResponseDefinition
+import io.codearte.accurest.util.AssertionUtil
+import spock.lang.Specification
+import spock.lang.Subject
+
+
+/**
+ * @author Norbert Krzysztofik
+ */
+class EchoRequestTransformerSpec extends Specification {
+
+    Request request = Stub()
+    ResponseDefinition responseDefinition = Stub()
+
+    @Subject
+    EchoRequestTransformer echoRequestTransformer = new EchoRequestTransformer()
+
+    def setup() {
+        responseDefinition.getByteBodyIfBinary() >> null
+    }
+
+
+    def 'shouldResponseWithUserIdFromRequestUrl'() {
+        given:
+        String url = '/get/user/12345/details'
+        String responseBody = '''
+                                    {
+                                       "id":"echoPathVariable(user)",
+                                       "surname":"Kowalsky",
+                                       "name":"Jan",
+                                       "created":"2014-02-02 12:23:43"
+                                    }
+                                    '''
+
+        request.getUrl() >> url
+        responseDefinition.getBody() >> responseBody
+
+        when:
+        ResponseDefinition transformedResponse = echoRequestTransformer.transform(request,
+                                                                                  responseDefinition, null, null)
+        then:
+        AssertionUtil.assertThatJsonsAreEqual('''
+                                                    {
+                                                       "id":"12345",
+                                                       "surname":"Kowalsky",
+                                                       "name":"Jan",
+                                                       "created":"2014-02-02 12:23:43"
+                                                    }
+                                                    ''', transformedResponse.getBody())
+    }
+
+    def 'shouldResponseWithPageNumberAndSizeFromRequestQueryParam'() {
+        given:
+            String url = '/get/user/12345/details?page=6&size=1'
+            String responseBody = '''{
+                                       "clients":[
+                                          {
+                                             "id":"12345",
+                                             "surname":"Kowalsky",
+                                             "name":"Jan",
+                                             "created":"2014-02-02 12:23:43"
+                                          }
+                                       ],
+                                       "pageMetadata":{
+                                          "size":echoQueryParam(size),
+                                          "totalElements":6,
+                                          "totalPages":6,
+                                          "number":echoQueryParam(page)
+                                       }
+                                    }
+                                '''
+            request.getUrl() >> url
+            request.queryParameter('page') >> new QueryParameter('page', ['6'])
+            request.queryParameter('size') >> new QueryParameter('size', ['1'])
+            responseDefinition.getBody() >> responseBody
+
+        when:
+            ResponseDefinition transformedResponse = echoRequestTransformer.transform(request,
+                                                                                      responseDefinition, null, null)
+        then:
+            AssertionUtil.assertThatJsonsAreEqual('''{
+                                                       "clients":[
+                                                          {
+                                                             "id":"12345",
+                                                             "surname":"Kowalsky",
+                                                             "name":"Jan",
+                                                             "created":"2014-02-02 12:23:43"
+                                                          }
+                                                       ],
+                                                       "pageMetadata":{
+                                                          "size":1,
+                                                          "totalElements":6,
+                                                          "totalPages":6,
+                                                          "number":6
+                                                       }
+                                                    }
+                                                ''', transformedResponse.getBody())
+    }
+
+    def 'shouldResponseWithDataTakenFromRequestBody'() {
+        given:
+            String url = '/patch/user/12345/address'
+            String requestBody = '''{
+                                     "city":"Warsaw",
+                                     "street":"Okopowa",
+                                     "number":30
+                                    }
+                                '''
+            String responseBody = '''{
+                                        "id":"12345",
+                                        "surname":"Kowalsky",
+                                        "name":"Jan",
+                                        "address": {
+                                             "city":"echoBodyElement(city)",
+                                             "street":"echoBodyElement(street)",
+                                             "number":echoBodyElement(number)
+                                            },
+                                        "created":"2014-02-02 12:23:43"
+                                        }
+                                    '''
+            request.getUrl() >> url
+            request.getBodyAsString() >> requestBody
+            responseDefinition.getBody() >> responseBody
+
+        when:
+            ResponseDefinition transformedResponse = echoRequestTransformer.transform(request,
+                                                                                      responseDefinition, null, null)
+        then:
+            AssertionUtil.assertThatJsonsAreEqual('''{
+                                                        "id":"12345",
+                                                        "surname":"Kowalsky",
+                                                        "name":"Jan",
+                                                        "address": {
+                                                             "city":"Warsaw",
+                                                             "street":"Okopowa",
+                                                             "number":30
+                                                            },
+                                                        "created":"2014-02-02 12:23:43"
+                                                        }
+                                                    ''', transformedResponse.getBody())
+    }
+}


### PR DESCRIPTION
This extension will allow stub runner client`s to publish more intelligent stubs which response with data taken from request body, path or query param. Please. see integration tests for concrete examples.
Next step could cover adding support for this extension in accurest dsl. 

Regards,
Norbert Krzysztofik
