### PR TITLE
Make AccuREST tasks cacheable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 sudo: required
 dist: trusty
+group: deprecated-2017Q2
 
 before_install:
  - "export JAVA_OPTS='-Xmx1024m -XX:MaxPermSize=256m'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,12 @@ before_install:
  - "mkdir $HOME/.m2/repository/io/codearte/accurest/ --parents"
  - "cp -r stub-runner/stub-runner-spring/src/test/resources/m2repo/repository/io/codearte/accurest/stubs $HOME/.m2/repository/io/codearte/accurest/"
 
-jdk:
- - oraclejdk8
-
 install: ./gradlew assemble -s
 script: ./gradlew check funcTest install -s --continue && jdk_switcher use oraclejdk8 && ./scripts/runTests.sh && jdk_switcher use $TRAVIS_JDK_VERSION && ./gradlew uploadSnapshotArchives -x check -s
 
 matrix:
   include:
+    - jdk: oraclejdk8
     # Automatic snapshot release only in Java 7 build
     - jdk: oraclejdk7
       env:

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WireMockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WireMockGroovyDslSpec.groovy
@@ -191,7 +191,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
   },
   "response" : {
 	"status" : 200,
-	"body" : "{\\"created\\":\\"2014-02-02 12:23:43\\",\\"id\\":\\"123\\",\\"name\\":\\"Jan\\",\\"surname\\":\\"Kowalsky\\"}",
+	"body" : "{\\"id\\":\\"123\\",\\"surname\\":\\"Kowalsky\\",\\"name\\":\\"Jan\\",\\"created\\":\\"2014-02-02 12:23:43\\"}",
 	"headers" : {
 	  "Content-Type" : "text/plain"
 	}

--- a/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WireMockGroovyDslSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/dsl/WireMockGroovyDslSpec.groovy
@@ -183,6 +183,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
 		when:
 			String wireMockStub = new WireMockStubStrategy("Test", new Contract(null, false, 0, null), groovyDsl).toWireMockClientStub()
 		then:
+			//TODO: That assertion fails on some environments due to 2 ways how body array is created - with 'created' at the beginning or 'id'
 		AssertionUtil.assertThatJsonsAreEqual(('''
 {
   "request" : {
@@ -191,7 +192,7 @@ class WireMockGroovyDslSpec extends Specification implements WireMockStubVerifie
   },
   "response" : {
 	"status" : 200,
-	"body" : "{\\"id\\":\\"123\\",\\"surname\\":\\"Kowalsky\\",\\"name\\":\\"Jan\\",\\"created\\":\\"2014-02-02 12:23:43\\"}",
+	"body" : "{\\"created\\":\\"2014-02-02 12:23:43\\",\\"id\\":\\"123\\",\\"name\\":\\"Jan\\",\\"surname\\":\\"Kowalsky\\"}",
 	"headers" : {
 	  "Content-Type" : "text/plain"
 	}

--- a/accurest-core/src/test/groovy/io/codearte/accurest/util/JsonToJsonPathsConverterSpec.groovy
+++ b/accurest-core/src/test/groovy/io/codearte/accurest/util/JsonToJsonPathsConverterSpec.groovy
@@ -180,16 +180,16 @@ class JsonToJsonPathsConverterSpec extends Specification {
 			JsonPaths pathAndValues = JsonToJsonPathsConverter.transformToJsonPathWithTestsSideValues(new JsonSlurper().parseText(json))
 		then:
 			pathAndValues.find {
-				it.method() == """.field("extensions").field("7").isEqualTo(28)""" &&
-				it.jsonPath() == '''$.extensions[?(@.7 == 28)]'''
+				it.method() == """.field("extensions").field("7").isEqualTo(28.00)""" &&
+				it.jsonPath() == '''$.extensions[?(@.7 == 28.00)]'''
 			}
 			pathAndValues.find {
-				it.method() == """.field("extensions").field("14").isEqualTo(41)""" &&
-				it.jsonPath() == '''$.extensions[?(@.14 == 41)]'''
+				it.method() == """.field("extensions").field("14").isEqualTo(41.00)""" &&
+				it.jsonPath() == '''$.extensions[?(@.14 == 41.00)]'''
 			}
 			pathAndValues.find {
-				it.method() == """.field("extensions").field("30").isEqualTo(60)""" &&
-				it.jsonPath() == '''$.extensions[?(@.30 == 60)]'''
+				it.method() == """.field("extensions").field("30").isEqualTo(60.00)""" &&
+				it.jsonPath() == '''$.extensions[?(@.30 == 60.00)]'''
 			}
 		and:
 			assertThatJsonPathsInMapAreValid(json, pathAndValues)

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/AccurestGradlePlugin.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/AccurestGradlePlugin.groovy
@@ -1,6 +1,6 @@
 package io.codearte.accurest.plugin
 
-import io.codearte.accurest.config.AccurestConfigProperties
+import io.codearte.accurest.plugin.config.AccurestGradleConfigProperties
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -20,7 +20,7 @@ class AccurestGradlePlugin implements Plugin<Project> {
 	@Override
 	void apply(Project project) {
 		this.project = project
-		AccurestConfigProperties extension = project.extensions.create('accurest', AccurestConfigProperties)
+		AccurestGradleConfigProperties extension = project.extensions.create('accurest', AccurestGradleConfigProperties)
 
 		project.check.dependsOn(GENERATE_SERVER_TESTS_TASK_NAME)
 
@@ -45,7 +45,7 @@ class AccurestGradlePlugin implements Plugin<Project> {
 		}
 	}
 
-	void setConfigurationDefaults(AccurestConfigProperties extension) {
+	void setConfigurationDefaults(AccurestGradleConfigProperties extension) {
 		extension.with {
 			generatedTestSourcesDir = project.file("${project.buildDir}/generated-test-sources/accurest")
 			contractsDslDir = defaultAccurestContractsDir() //TODO: Use sourceset
@@ -57,24 +57,20 @@ class AccurestGradlePlugin implements Plugin<Project> {
 		project.file("${project.rootDir}/src/test/resources/accurest")
 	}
 
-	private void createGenerateTestsTask(AccurestConfigProperties extension) {
+	private void createGenerateTestsTask(AccurestGradleConfigProperties extension) {
 		Task task = project.tasks.create(GENERATE_SERVER_TESTS_TASK_NAME, GenerateServerTestsTask)
 		task.description = "Generate server tests from GroovyDSL"
 		task.group = GROUP_NAME
 		task.conventionMapping.with {
-			contractsDslDir = { extension.contractsDslDir }
-			generatedTestSourcesDir = { extension.generatedTestSourcesDir }
 			configProperties = { extension }
 		}
 	}
 
-	private void createAndConfigureGenerateWireMockClientStubsFromDslTask(AccurestConfigProperties extension) {
+	private void createAndConfigureGenerateWireMockClientStubsFromDslTask(AccurestGradleConfigProperties extension) {
 		Task task = project.tasks.create(DSL_TO_WIREMOCK_CLIENT_TASK_NAME, GenerateWireMockClientStubsFromDslTask)
 		task.description = "Generate WireMock client stubs from GroovyDSL"
 		task.group = GROUP_NAME
 		task.conventionMapping.with {
-			contractsDslDir = { extension.contractsDslDir }
-			stubsOutputDir = { extension.stubsOutputDir }
 			configProperties = { extension }
 		}
 	}

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/AccurestGradlePlugin.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/AccurestGradlePlugin.groovy
@@ -1,6 +1,8 @@
 package io.codearte.accurest.plugin
 
-import io.codearte.accurest.plugin.config.AccurestGradleConfigProperties
+import io.codearte.accurest.plugin.config.AccurestClientStubsTaskConfigProperties
+import io.codearte.accurest.plugin.config.AccurestGenericGradleConfigProperties
+import io.codearte.accurest.plugin.config.AccurestServerTestsTaskConfigProperties
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -20,7 +22,7 @@ class AccurestGradlePlugin implements Plugin<Project> {
 	@Override
 	void apply(Project project) {
 		this.project = project
-		AccurestGradleConfigProperties extension = project.extensions.create('accurest', AccurestGradleConfigProperties)
+		AccurestGenericGradleConfigProperties extension = project.extensions.create('accurest', AccurestGenericGradleConfigProperties)
 
 		project.check.dependsOn(GENERATE_SERVER_TESTS_TASK_NAME)
 
@@ -45,7 +47,7 @@ class AccurestGradlePlugin implements Plugin<Project> {
 		}
 	}
 
-	void setConfigurationDefaults(AccurestGradleConfigProperties extension) {
+	void setConfigurationDefaults(AccurestGenericGradleConfigProperties extension) {
 		extension.with {
 			generatedTestSourcesDir = project.file("${project.buildDir}/generated-test-sources/accurest")
 			contractsDslDir = defaultAccurestContractsDir() //TODO: Use sourceset
@@ -57,21 +59,21 @@ class AccurestGradlePlugin implements Plugin<Project> {
 		project.file("${project.rootDir}/src/test/resources/accurest")
 	}
 
-	private void createGenerateTestsTask(AccurestGradleConfigProperties extension) {
+	private void createGenerateTestsTask(AccurestGenericGradleConfigProperties extension) {
 		Task task = project.tasks.create(GENERATE_SERVER_TESTS_TASK_NAME, GenerateServerTestsTask)
 		task.description = "Generate server tests from GroovyDSL"
 		task.group = GROUP_NAME
 		task.conventionMapping.with {
-			configProperties = { extension }
+			configProperties = { AccurestServerTestsTaskConfigProperties.fromGenericConfig(extension) }
 		}
 	}
 
-	private void createAndConfigureGenerateWireMockClientStubsFromDslTask(AccurestGradleConfigProperties extension) {
+	private void createAndConfigureGenerateWireMockClientStubsFromDslTask(AccurestGenericGradleConfigProperties extension) {
 		Task task = project.tasks.create(DSL_TO_WIREMOCK_CLIENT_TASK_NAME, GenerateWireMockClientStubsFromDslTask)
 		task.description = "Generate WireMock client stubs from GroovyDSL"
 		task.group = GROUP_NAME
 		task.conventionMapping.with {
-			configProperties = { extension }
+			configProperties = { AccurestClientStubsTaskConfigProperties.fromGenericConfig(extension) }
 		}
 	}
 

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateServerTestsTask.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateServerTestsTask.groovy
@@ -2,22 +2,18 @@ package io.codearte.accurest.plugin
 
 import io.codearte.accurest.AccurestException
 import io.codearte.accurest.TestGenerator
-import io.codearte.accurest.config.AccurestConfigProperties
+import io.codearte.accurest.plugin.config.AccurestGradleConfigProperties
 import org.gradle.api.GradleException
 import org.gradle.api.internal.ConventionTask
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 class GenerateServerTestsTask extends ConventionTask {
 
-	@InputDirectory
-	File contractsDslDir
-	@OutputDirectory
-	File generatedTestSourcesDir
-
-	//TODO: How to deal with @Input*, @Output* and that domain object?
-	AccurestConfigProperties configProperties
+	@Nested
+	AccurestGradleConfigProperties configProperties
 
 	@TaskAction
 	void generate() {

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateServerTestsTask.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateServerTestsTask.groovy
@@ -2,7 +2,7 @@ package io.codearte.accurest.plugin
 
 import io.codearte.accurest.AccurestException
 import io.codearte.accurest.TestGenerator
-import io.codearte.accurest.plugin.config.AccurestGradleConfigProperties
+import io.codearte.accurest.plugin.config.AccurestServerTestsTaskConfigProperties
 import org.gradle.api.GradleException
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.CacheableTask
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.TaskAction
 class GenerateServerTestsTask extends ConventionTask {
 
 	@Nested
-	AccurestGradleConfigProperties configProperties
+	AccurestServerTestsTaskConfigProperties configProperties
 
 	@TaskAction
 	void generate() {

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWireMockClientStubsFromDslTask.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWireMockClientStubsFromDslTask.groovy
@@ -1,29 +1,24 @@
 package io.codearte.accurest.plugin
 
-import io.codearte.accurest.config.AccurestConfigProperties
+import io.codearte.accurest.plugin.config.AccurestGradleConfigProperties
 import io.codearte.accurest.wiremock.DslToWireMockClientConverter
 import io.codearte.accurest.wiremock.RecursiveFilesConverter
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 
 //TODO: Implement as an incremental task: https://gradle.org/docs/current/userguide/custom_tasks.html#incremental_tasks ?
 @CacheableTask
 class GenerateWireMockClientStubsFromDslTask extends ConventionTask {
 
-	@InputDirectory
-	File contractsDslDir
-	@OutputDirectory
-	File stubsOutputDir
-
-	AccurestConfigProperties configProperties
+	@Nested
+	AccurestGradleConfigProperties configProperties
 
 	@TaskAction
 	void generate() {
 		logger.info("Accurest Plugin: Invoking GroovyDSL to WireMock client stubs conversion")
-		logger.debug("From '${getContractsDslDir()}' to '${getStubsOutputDir()}'")
+		logger.debug("From '${getConfigProperties().getContractsDslDir()}' to '${getConfigProperties().getStubsOutputDir()}'")
 		RecursiveFilesConverter converter = new RecursiveFilesConverter(new DslToWireMockClientConverter(), getConfigProperties())
 		converter.processFiles()
 	}

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWireMockClientStubsFromDslTask.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWireMockClientStubsFromDslTask.groovy
@@ -4,11 +4,13 @@ import io.codearte.accurest.config.AccurestConfigProperties
 import io.codearte.accurest.wiremock.DslToWireMockClientConverter
 import io.codearte.accurest.wiremock.RecursiveFilesConverter
 import org.gradle.api.internal.ConventionTask
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 //TODO: Implement as an incremental task: https://gradle.org/docs/current/userguide/custom_tasks.html#incremental_tasks ?
+@CacheableTask
 class GenerateWireMockClientStubsFromDslTask extends ConventionTask {
 
 	@InputDirectory

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWireMockClientStubsFromDslTask.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/GenerateWireMockClientStubsFromDslTask.groovy
@@ -1,6 +1,6 @@
 package io.codearte.accurest.plugin
 
-import io.codearte.accurest.plugin.config.AccurestGradleConfigProperties
+import io.codearte.accurest.plugin.config.AccurestClientStubsTaskConfigProperties
 import io.codearte.accurest.wiremock.DslToWireMockClientConverter
 import io.codearte.accurest.wiremock.RecursiveFilesConverter
 import org.gradle.api.internal.ConventionTask
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.TaskAction
 class GenerateWireMockClientStubsFromDslTask extends ConventionTask {
 
 	@Nested
-	AccurestGradleConfigProperties configProperties
+	AccurestClientStubsTaskConfigProperties configProperties
 
 	@TaskAction
 	void generate() {

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestClientStubsTaskConfigProperties.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestClientStubsTaskConfigProperties.groovy
@@ -1,0 +1,41 @@
+package io.codearte.accurest.plugin.config
+
+import groovy.transform.CompileStatic
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+
+@CompileStatic
+class AccurestClientStubsTaskConfigProperties extends AccurestGenericGradleConfigProperties {
+
+	@Override
+	@Input
+	List<String> getExcludedFiles() {
+		return super.getExcludedFiles()
+	}
+
+	@Override
+	@Input
+	List<String> getIgnoredFiles() {
+		return super.getIgnoredFiles()
+	}
+
+	@Override
+	@InputDirectory
+	File getContractsDslDir() {
+		return super.getContractsDslDir()
+	}
+
+	@Override
+	@OutputDirectory
+	File getStubsOutputDir() {
+		return super.getStubsOutputDir()
+	}
+
+	static AccurestClientStubsTaskConfigProperties fromGenericConfig(AccurestGenericGradleConfigProperties configToCloneFrom) {
+		return new AccurestClientStubsTaskConfigProperties().with {
+			it.clonePropertiesFrom(configToCloneFrom)
+			return it
+		}
+	}
+}

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestGenericGradleConfigProperties.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestGenericGradleConfigProperties.groovy
@@ -1,0 +1,26 @@
+package io.codearte.accurest.plugin.config
+
+import groovy.transform.CompileStatic
+import io.codearte.accurest.config.AccurestConfigProperties
+
+@CompileStatic
+class AccurestGenericGradleConfigProperties extends AccurestConfigProperties {
+
+	protected void clonePropertiesFrom(AccurestGenericGradleConfigProperties configToCloneFrom) {
+		//shallow copy which is enough to make workaround for overlapping outputs in tasks
+		targetFramework = configToCloneFrom.targetFramework
+		testMode = configToCloneFrom.testMode
+		basePackageForTests = configToCloneFrom.basePackageForTests
+		baseClassForTests = configToCloneFrom.baseClassForTests
+		nameSuffixForTests = configToCloneFrom.nameSuffixForTests
+		ruleClassForTests = configToCloneFrom.ruleClassForTests
+		jsonAssertVersion = configToCloneFrom.jsonAssertVersion
+		excludedFiles = configToCloneFrom.excludedFiles
+		ignoredFiles = configToCloneFrom.ignoredFiles
+		imports = configToCloneFrom.imports
+		staticImports = configToCloneFrom.staticImports
+		contractsDslDir = configToCloneFrom.contractsDslDir
+		generatedTestSourcesDir = configToCloneFrom.generatedTestSourcesDir
+		stubsOutputDir = configToCloneFrom.stubsOutputDir
+	}
+}

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestGradleConfigProperties.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestGradleConfigProperties.groovy
@@ -1,0 +1,101 @@
+package io.codearte.accurest.plugin.config
+
+import groovy.transform.CompileStatic
+import io.codearte.accurest.config.AccurestConfigProperties
+import io.codearte.accurest.config.TestFramework
+import io.codearte.accurest.config.TestMode
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+
+@CompileStatic
+class AccurestGradleConfigProperties extends AccurestConfigProperties {
+
+	@Override
+	@Input
+	TestFramework getTargetFramework() {
+		return super.getTargetFramework()
+	}
+
+	@Override
+	@Input
+	TestMode getTestMode() {
+		return super.getTestMode()
+	}
+
+	@Override
+	@Input
+	String getBasePackageForTests() {
+		return super.getBasePackageForTests()
+	}
+
+	@Override
+	@Input
+	@Optional
+	String getBaseClassForTests() {
+		return super.getBaseClassForTests()
+	}
+
+	@Override
+	@Input
+	@Optional
+	String getNameSuffixForTests() {
+		return super.getNameSuffixForTests()
+	}
+
+	@Override
+	@Input
+	@Optional
+	String getRuleClassForTests() {
+		return super.getRuleClassForTests()
+	}
+
+	@Override
+	@Input
+	String getJsonAssertVersion() {
+		return super.getJsonAssertVersion()
+	}
+
+	@Override
+	@Input
+	List<String> getExcludedFiles() {
+		return super.getExcludedFiles()
+	}
+
+	@Override
+	@Input
+	List<String> getIgnoredFiles() {
+		return super.getIgnoredFiles()
+	}
+
+	@Override
+	@Input
+	String[] getImports() {
+		return super.getImports()
+	}
+
+	@Override
+	@Input
+	String[] getStaticImports() {
+		return super.getStaticImports()
+	}
+
+	@Override
+	@InputDirectory
+	File getContractsDslDir() {
+		return super.getContractsDslDir()
+	}
+
+	@Override
+	@OutputDirectory
+	File getGeneratedTestSourcesDir() {
+		return super.getGeneratedTestSourcesDir()
+	}
+
+	@Override
+	@OutputDirectory
+	File getStubsOutputDir() {
+		return super.getStubsOutputDir()
+	}
+}

--- a/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestServerTestsTaskConfigProperties.groovy
+++ b/accurest-gradle-plugin/src/main/groovy/io/codearte/accurest/plugin/config/AccurestServerTestsTaskConfigProperties.groovy
@@ -1,7 +1,6 @@
 package io.codearte.accurest.plugin.config
 
 import groovy.transform.CompileStatic
-import io.codearte.accurest.config.AccurestConfigProperties
 import io.codearte.accurest.config.TestFramework
 import io.codearte.accurest.config.TestMode
 import org.gradle.api.tasks.Input
@@ -10,7 +9,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 
 @CompileStatic
-class AccurestGradleConfigProperties extends AccurestConfigProperties {
+class AccurestServerTestsTaskConfigProperties extends AccurestGenericGradleConfigProperties {
 
 	@Override
 	@Input
@@ -93,9 +92,10 @@ class AccurestGradleConfigProperties extends AccurestConfigProperties {
 		return super.getGeneratedTestSourcesDir()
 	}
 
-	@Override
-	@OutputDirectory
-	File getStubsOutputDir() {
-		return super.getStubsOutputDir()
+	static AccurestServerTestsTaskConfigProperties fromGenericConfig(AccurestGenericGradleConfigProperties configToCloneFrom) {
+		return new AccurestServerTestsTaskConfigProperties().with {
+			it.clonePropertiesFrom(configToCloneFrom)
+			return it
+		}
 	}
 }

--- a/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/AccurestIntegrationSpec.groovy
+++ b/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/AccurestIntegrationSpec.groovy
@@ -67,7 +67,7 @@ abstract class AccurestIntegrationSpec extends Specification {
 	protected void runTasksSuccessfully(String... tasks) {
 		BuildResult result = run(tasks)
 		result.tasks.each {
-			assert it.outcome == TaskOutcome.SUCCESS || it.outcome == TaskOutcome.UP_TO_DATE
+			assert it.outcome == TaskOutcome.SUCCESS || it.outcome == TaskOutcome.UP_TO_DATE || it.outcome == TaskOutcome.NO_SOURCE
 		}
 	}
 

--- a/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
+++ b/accurest-gradle-plugin/src/test/groovy/io/codearte/accurest/plugin/BasicFunctionalSpec.groovy
@@ -12,7 +12,7 @@ class BasicFunctionalSpec extends AccurestIntegrationSpec {
 	private static final String GENERATED_TEST = "build//generated-test-sources//accurest//accurest//com//ofg//twitter_places_analyzer//PairIdSpec.groovy"
 	private static final String GENERATED_CLIENT_JSON_STUB = "build//production//bootSimple-stubs//repository//mappings//com//ofg//twitter-places-analyzer//pairId//collerate_PlacesFrom_Tweet.json"
 	private static final String GROOVY_DSL_CONTRACT = "repository//mappings//com//ofg//twitter-places-analyzer//pairId//collerate_PlacesFrom_Tweet.groovy"
-	private static final String TEST_EXECUTION_XML_REPORT = "build/test-results/TEST-accurest.com.ofg.twitter_places_analyzer.PairIdSpec.xml"
+	private static final String TEST_EXECUTION_XML_REPORT = "build/test-results/test/TEST-accurest.com.ofg.twitter_places_analyzer.PairIdSpec.xml"
 
 	def setup() {
 		setupForProject("functionalTest/bootSimple")

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/bootSimple/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/bootSimple/build.gradle
@@ -39,11 +39,11 @@ repositories {
 dependencies {
 	compile "org.springframework:spring-web:$springVersion"
 	compile "org.springframework:spring-context-support:$springVersion"
-	compile "org.codehaus.groovy:groovy-all:2.4.5"
+	compile "org.codehaus.groovy:groovy-all:2.4.10"
 	compile 'com.jayway.jsonpath:json-path-assert:2.2.0'
 
 	testCompile "com.github.tomakehurst:wiremock:2.0.10-beta"
-	testCompile "org.spockframework:spock-spring:1.0-groovy-2.4"
+	testCompile "org.spockframework:spock-spring:1.1-groovy-2.4"
 	testCompile "com.jayway.restassured:rest-assured:$restAssuredVersion"
 	testCompile "com.jayway.restassured:spring-mock-mvc:$restAssuredVersion"
 	testCompile "ch.qos.logback:logback-classic:1.1.2"

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/bootSimple/gradle.properties
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/bootSimple/gradle.properties
@@ -1,6 +1,6 @@
 groupId=com.ofg
 jacksonMapper=1.9.13
 restAssuredVersion=2.4.0
-springVersion=4.1.7.RELEASE
+springVersion=4.3.9.RELEASE
 
-springBootVersion=1.3.3.RELEASE
+springBootVersion=1.4.7.RELEASE

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/messagingProject/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/messagingProject/build.gradle
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-	compile "org.codehaus.groovy:groovy-all:2.4.5"
+	compile "org.codehaus.groovy:groovy-all:2.4.10"
 	compile "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
 	compile "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
 	compile "org.springframework.boot:spring-boot-starter-integration:${springBootVersion}"
@@ -54,6 +54,7 @@ dependencies {
 
 	testCompile "org.spockframework:spock-spring:1.0-groovy-2.4"
 	testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+//	testCompile "org.springframework.boot:spring-boot-test"
 	testCompile "ch.qos.logback:logback-classic:1.1.2"
 	testCompile 'com.jayway.restassured:spring-mock-mvc:2.9.0' // needed if you're going to use Spring MockMvc
 }

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/messagingProject/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/messagingProject/build.gradle
@@ -54,7 +54,6 @@ dependencies {
 
 	testCompile "org.spockframework:spock-spring:1.0-groovy-2.4"
 	testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
-//	testCompile "org.springframework.boot:spring-boot-test"
 	testCompile "ch.qos.logback:logback-classic:1.1.2"
 	testCompile 'com.jayway.restassured:spring-mock-mvc:2.9.0' // needed if you're going to use Spring MockMvc
 }

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/build.gradle
@@ -27,7 +27,7 @@ subprojects {
 	}
 
 	dependencies {
-		testCompile 'org.codehaus.groovy:groovy-all:2.4.5'
+		testCompile 'org.codehaus.groovy:groovy-all:2.4.10'
 		testCompile "org.spockframework:spock-core:$spockVersion"
 		testCompile 'junit:junit:4.12'
 		testCompile "com.github.tomakehurst:wiremock:$wiremockVersion"

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:1.2.6.RELEASE"
+		classpath "org.springframework.boot:spring-boot-gradle-plugin:1.4.0.RELEASE"
 	}
 }
 
@@ -12,8 +12,8 @@ group = 'io.codearte.accurest.testprojects'
 
 ext {
 	restAssuredVersion = '2.5.0'
-	spockVersion = '1.0-groovy-2.4'
-	wiremockVersion = '2.0.10-beta'
+	spockVersion = '1.1-groovy-2.4'
+	wiremockVersion = '2.1.7'
 
 	accurestStubsBaseDirectory = 'src/test/resources/stubs'
 }
@@ -45,6 +45,7 @@ configure([project(':fraudDetectionService'), project(':loanApplicationService')
 		wireMockStubsOutputDir = file(new File(stubsOutputDirRoot, 'repository/mappings/'))
 		contractsOutputDir = file(new File(stubsOutputDirRoot, 'repository/accurest/'))
 	}
+	ext['jetty.version'] = '9.2.17.v20160517'
 
 	accurest {
 		targetFramework = 'Spock'
@@ -64,14 +65,23 @@ configure([project(':fraudDetectionService'), project(':loanApplicationService')
 	}
 
 	dependencies {
-		compile 'org.glassfish.jersey.containers:jersey-container-jetty-http:2.15'
+		compile('org.glassfish.jersey.containers:jersey-container-jetty-http:2.23.2') {
+			exclude group: 'org.eclipse.jetty'
+		}
 		compile 'org.springframework.boot:spring-boot-starter-jersey'
 		compile 'org.springframework.boot:spring-boot-starter-jetty'
 
 		testRuntime "org.spockframework:spock-spring:$spockVersion"
 
-		compile 'org.glassfish.jersey.connectors:jersey-apache-connector:2.15'
-		testCompile 'org.springframework:spring-test'
+		compile('org.glassfish.jersey.connectors:jersey-apache-connector:2.23.2') {
+			exclude group: 'org.eclipse.jetty'
+		}
+		testCompile "org.mockito:mockito-core"
+		testCompile "org.springframework:spring-test"
+		testCompile "org.springframework.boot:spring-boot-test"
+		testCompile("com.github.tomakehurst:wiremock:2.1.7") {
+			exclude group: 'org.eclipse.jetty'
+		}
 	}
 
 	task cleanup(type: Delete) {

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/loanApplicationService/src/test/groovy/com/blogspot/toomuchcoding/LoanApplicationServiceSpec.groovy
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleJerseyProject/loanApplicationService/src/test/groovy/com/blogspot/toomuchcoding/LoanApplicationServiceSpec.groovy
@@ -9,12 +9,12 @@ import com.blogspot.toomuchcoding.frauddetection.model.LoanApplicationStatus
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule
 import org.junit.ClassRule
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Shared
 import spock.lang.Specification
 
-@ContextConfiguration(loader = SpringApplicationContextLoader, classes = Application)
+@ContextConfiguration(loader = SpringBootContextLoader, classes = Application)
 class LoanApplicationServiceSpec extends Specification {
 
 	public static int port = org.springframework.util.SocketUtils.findAvailableTcpPort()

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/build.gradle
@@ -34,7 +34,6 @@ subprojects {
 		testCompile("com.github.tomakehurst:wiremock:$wiremockVersion") {
 			exclude group: 'org.eclipse.jetty'
 		}
-
 	}
 }
 

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/build.gradle
@@ -4,17 +4,18 @@ buildscript {
 		mavenLocal()
 	}
 	dependencies {
-		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.6.RELEASE")
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.0.RELEASE")
 	}
 }
 
 ext {
 	restAssuredVersion = '2.5.0'
 	spockVersion = '1.0-groovy-2.4'
-	wiremockVersion = '2.0.10-beta'
+	wiremockVersion = '2.1.7'
 
 	accurestStubsBaseDirectory = 'src/test/resources/stubs'
 }
+ext['jetty.version'] = '9.2.17.v20160517'
 
 group = 'io.codearte.accurest.testprojects'
 
@@ -27,10 +28,13 @@ subprojects {
 	}
 
 	dependencies {
-		testCompile "org.codehaus.groovy:groovy-all:2.4.5"
+		testCompile "org.codehaus.groovy:groovy-all:2.4.10"
 		testCompile "org.spockframework:spock-core:$spockVersion"
 		testCompile("junit:junit:4.12")
-		testCompile "com.github.tomakehurst:wiremock:$wiremockVersion"
+		testCompile("com.github.tomakehurst:wiremock:$wiremockVersion") {
+			exclude group: 'org.eclipse.jetty'
+		}
+
 	}
 }
 
@@ -67,7 +71,9 @@ configure([project(':fraudDetectionService'), project(':loanApplicationService')
 		compile("org.springframework.boot:spring-boot-starter-actuator")
 
 		testRuntime "org.spockframework:spock-spring:$spockVersion"
+		testCompile "org.mockito:mockito-core"
 		testCompile "org.springframework:spring-test"
+		testCompile "org.springframework.boot:spring-boot-test"
 		testCompile "com.jayway.restassured:rest-assured:$restAssuredVersion"
 		testCompile "com.jayway.restassured:spring-mock-mvc:$restAssuredVersion"
 	}

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/fraudDetectionService/mappings/fraudDetectionService/shouldMarkClientAsFraud.groovy
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/fraudDetectionService/mappings/fraudDetectionService/shouldMarkClientAsFraud.groovy
@@ -20,7 +20,7 @@ io.codearte.accurest.dsl.GroovyDsl.make {
 	"rejectionReason": "Amount too high"
 }""")
 				headers {
-					 header('Content-Type': 'application/vnd.fraud.v1+json')
+					header('Content-Type': 'application/vnd.fraud.v1+json;charset=UTF-8')
 					}
 			}
 

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/fraudDetectionService/mappings/fraudDetectionService/shouldMarkClientAsNotFraud.groovy
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/fraudDetectionService/mappings/fraudDetectionService/shouldMarkClientAsNotFraud.groovy
@@ -21,7 +21,7 @@ io.codearte.accurest.dsl.GroovyDsl.make {
 						rejectionReason: $(client(null), server(execute('assertThatRejectionReasonIsNull($it)')))
 				)
 				headers {
-					 header('Content-Type': 'application/vnd.fraud.v1+json')
+					header('Content-Type': 'application/vnd.fraud.v1+json;charset=UTF-8')
 				}
 			}
 

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/loanApplicationService/src/test/groovy/com/blogspot/toomuchcoding/LoanApplicationServiceSpec.groovy
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/sampleProject/loanApplicationService/src/test/groovy/com/blogspot/toomuchcoding/LoanApplicationServiceSpec.groovy
@@ -9,12 +9,12 @@ import com.blogspot.toomuchcoding.frauddetection.model.LoanApplicationStatus
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule
 import org.junit.ClassRule
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Shared
 import spock.lang.Specification
 
-@ContextConfiguration(loader = SpringApplicationContextLoader, classes = Application)
+@ContextConfiguration(loader = SpringBootContextLoader, classes = Application)
 class LoanApplicationServiceSpec extends Specification {
 
 	public static int port = org.springframework.util.SocketUtils.findAvailableTcpPort()

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/build.gradle
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/build.gradle
@@ -4,17 +4,18 @@ buildscript {
 		mavenLocal()
 	}
 	dependencies {
-		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.6.RELEASE")
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.0.RELEASE")
 	}
 }
 
 ext {
 	restAssuredVersion = '2.5.0'
 	spockVersion = '1.0-groovy-2.4'
-	wiremockVersion = '2.0.10-beta'
+	wiremockVersion = '2.1.7'
 
 	accurestStubsBaseDirectory = 'src/test/resources/stubs'
 }
+ext['jetty.version'] = '9.2.17.v20160517'
 
 group = 'io.codearte.accurest.testprojects'
 
@@ -28,10 +29,12 @@ subprojects {
 	}
 
 	dependencies {
-		testCompile "org.codehaus.groovy:groovy-all:2.4.5"
+		testCompile "org.codehaus.groovy:groovy-all:2.4.10"
 		testCompile "org.spockframework:spock-core:$spockVersion"
 		testCompile("junit:junit:4.12")
-		testCompile "com.github.tomakehurst:wiremock:$wiremockVersion"
+		testCompile("com.github.tomakehurst:wiremock:$wiremockVersion") {
+			exclude group: 'org.eclipse.jetty'
+		}
 	}
 }
 
@@ -96,7 +99,9 @@ configure([project(':fraudDetectionService'), project(':loanApplicationService')
 		compile("org.springframework.boot:spring-boot-starter-actuator")
 
 		testRuntime "org.spockframework:spock-spring:$spockVersion"
+		testCompile "org.mockito:mockito-core"
 		testCompile "org.springframework:spring-test"
+		testCompile "org.springframework.boot:spring-boot-test"
 		testCompile "com.jayway.restassured:rest-assured:$restAssuredVersion"
 		testCompile "com.jayway.restassured:spring-mock-mvc:$restAssuredVersion"
 	}

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/fraudDetectionService/mappings/fraudDetectionService/1_shouldMarkClientAsNotFraud.groovy
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/fraudDetectionService/mappings/fraudDetectionService/1_shouldMarkClientAsNotFraud.groovy
@@ -21,7 +21,7 @@ io.codearte.accurest.dsl.GroovyDsl.make {
 						rejectionReason: $(client(null), server(execute('assertThatRejectionReasonIsNull($it)')))
 				)
 				headers {
-					 header('Content-Type': 'application/vnd.fraud.v1+json')
+					 header('Content-Type': 'application/vnd.fraud.v1+json;charset=UTF-8')
 				}
 			}
 

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/fraudDetectionService/mappings/fraudDetectionService/2_shouldMarkClientAsFraud.groovy
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/fraudDetectionService/mappings/fraudDetectionService/2_shouldMarkClientAsFraud.groovy
@@ -20,8 +20,8 @@ io.codearte.accurest.dsl.GroovyDsl.make {
 	"rejectionReason": "Amount too high"
 }""")
 				headers {
-					 header('Content-Type': 'application/vnd.fraud.v1+json')
-					}
+					header('Content-Type': 'application/vnd.fraud.v1+json;charset=UTF-8')
+				}
 			}
 
 }

--- a/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/loanApplicationService/src/test/groovy/com/blogspot/toomuchcoding/LoanApplicationServiceSpec.groovy
+++ b/accurest-gradle-plugin/src/test/resources/functionalTest/scenarioProject/loanApplicationService/src/test/groovy/com/blogspot/toomuchcoding/LoanApplicationServiceSpec.groovy
@@ -9,13 +9,13 @@ import com.blogspot.toomuchcoding.frauddetection.model.LoanApplicationStatus
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule
 import org.junit.ClassRule
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.boot.test.context.SpringBootContextLoader
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Stepwise
 
-@ContextConfiguration(loader = SpringApplicationContextLoader, classes = Application)
+@ContextConfiguration(loader = SpringBootContextLoader, classes = Application)
 @Stepwise
 class LoanApplicationServiceSpec extends Specification {
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 		if (project.hasProperty('fatJar')) jcenter()
 	}
 	dependencies {
-		classpath "pl.allegro.tech.build:axion-release-plugin:1.3.2"
+		classpath "pl.allegro.tech.build:axion-release-plugin:1.4.1"
 		classpath "com.bmuschko:gradle-nexus-plugin:2.3"
 		classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
 		if (project.hasProperty('fatJar')) classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'

--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ project(':accurest-gradle-plugin') {
 		messagingLibs project(':accurest-messaging-root:accurest-messaging-integration')
 		messagingLibs project(':accurest-messaging-root:accurest-messaging-core')
 		messagingLibs project(':accurest-testing-utils')
-		messagingLibs 'org.codehaus.groovy:groovy-all:2.4.5'
+		messagingLibs 'org.codehaus.groovy:groovy-all:2.4.10'
 
 		accurestGradlePluginLibs project(':accurest-gradle-plugin')
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ project(':accurest-core') {
 		compile 'org.apache.commons:commons-lang3:3.3'
 		compile "com.github.tomakehurst:wiremock:$wiremockVersion"
 		compile "com.toomuchcoding.jsonassert:jsonassert:$jsonassertVersion"
-		compile 'org.codehaus.groovy:groovy-all:2.4.4'
+		compile 'org.codehaus.groovy:groovy-all:2.4.10'
 		testCompile 'cglib:cglib-nodep:2.2'
 		testCompile 'org.objenesis:objenesis:2.1'
 		testCompile project(':accurest-testing-utils')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 12 23:29:55 EDT 2016
+#Thu Jul 06 12:13:23 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-bin.zip

--- a/stub-runner/stub-runner-messaging/stub-runner-messaging-camel/src/test/groovy/io/codearte/accurest/stubrunner/messaging/camel/CamelStubRunnerSpec.groovy
+++ b/stub-runner/stub-runner-messaging/stub-runner-messaging-camel/src/test/groovy/io/codearte/accurest/stubrunner/messaging/camel/CamelStubRunnerSpec.groovy
@@ -145,9 +145,12 @@ class CamelStubRunnerSpec extends Specification {
 		return json.bookName == 'foo'
 	}
 
-	@Bean
-	ActiveMQComponent activeMQComponent(@Value('${activemq.url:vm://localhost?broker.persistent=false}') String url) {
-		return new ActiveMQComponent(brokerURL: url)
+	@Configuration
+	private static class AvtiveMQConfiguration {
+		@Bean
+		ActiveMQComponent activeMQComponent(@Value('${activemq.url:vm://localhost?broker.persistent=false}') String url) {
+			return new ActiveMQComponent(brokerURL: url)
+		}
 	}
 
 	GroovyDsl dsl =

--- a/stub-runner/stub-runner-messaging/stub-runner-messaging-stream/build.gradle
+++ b/stub-runner/stub-runner-messaging/stub-runner-messaging-stream/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
 	testCompile "org.springframework:spring-context:${springVersion}"
 	testCompile "org.springframework:spring-beans:${springVersion}"
+	testCompile "org.springframework:spring-web:${springVersion}"
 	testCompile "org.springframework.cloud:spring-cloud-stream-test-support:${springStreamVersion}"
 	testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
 	testCompile('org.spockframework:spock-spring:1.0-groovy-2.4') {

--- a/stub-runner/stub-runner/build.gradle
+++ b/stub-runner/stub-runner/build.gradle
@@ -6,7 +6,7 @@ mainClassName = 'io.codearte.accurest.stubrunner.StubRunnerMain'
 dependencies {
 	compile project(':accurest-core')
 	compile project(':accurest-messaging-root:accurest-messaging-core')
-	compile 'org.codehaus.groovy:groovy-all:2.4.4'
+	compile 'org.codehaus.groovy:groovy-all:2.4.10'
 	compile "com.github.tomakehurst:wiremock:$wiremockVersion"
 	compile 'javax.servlet:javax.servlet-api:3.1.0'
 	compile 'args4j:args4j:2.32'

--- a/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/StubRepository.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/StubRepository.groovy
@@ -45,7 +45,7 @@ class StubRepository {
 	}
 
 	private List<WiremockMappingDescriptor> contextDescriptors() {
-		return path.exists() ? collectMappingDescriptors(path) : []
+		return path.exists() ? collectMappingDescriptors(path) : [] as List<WiremockMappingDescriptor>
 	}
 
 	private List<WiremockMappingDescriptor> collectMappingDescriptors(File descriptorsDirectory) {
@@ -59,7 +59,7 @@ class StubRepository {
 	}
 
 	private Collection<GroovyDsl> accurestDescriptors() {
-		return path.exists() ? collectAccurestDescriptors(path) : []
+		return path.exists() ? collectAccurestDescriptors(path) : [] as Collection<GroovyDsl>
 	}
 
 	private Collection<GroovyDsl> collectAccurestDescriptors(File descriptorsDirectory) {

--- a/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/StubRunnerExecutor.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/StubRunnerExecutor.groovy
@@ -104,7 +104,7 @@ class StubRunnerExecutor implements StubFinder {
 	Map<String, Collection<String>> labels() {
 		return getAccurestContracts().collectEntries {
 			[(it.key.toColonSeparatedDependencyNotation()) : it.value.collect { it.label }]
-		} as Map<String, List<String>>
+		} as Map<String, Collection<String>>
 	}
 
 	private void sendMessageIfApplicable(GroovyDsl groovyDsl) {

--- a/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/StubRunnerOptionsBuilder.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/io/codearte/accurest/stubrunner/StubRunnerOptionsBuilder.groovy
@@ -90,7 +90,7 @@ class StubRunnerOptionsBuilder {
 	}
 
 	private static List<String> stubsToList(String stubIdsToPortMapping) {
-		return stubIdsToPortMapping.split(',').collect { it }
+		return stubIdsToPortMapping.split(',').toList()
 	}
 
 	private void addStub(List<String> notations) {


### PR DESCRIPTION
AccuREST tasks are cacheable. To do that a hack to provide distinct configuration with not overlapping outputs has to be used.

To be able to use `@CacheableTask` annotation project had to be upgraded to Gradle 3 which in turn requires newer Spring Boot (which was painful...).